### PR TITLE
Disable 32bit intel

### DIFF
--- a/cabal2spec/Main.hs
+++ b/cabal2spec/Main.hs
@@ -7,7 +7,6 @@ import Cabal2Spec
 import Paths_cabal2spec ( version )
 
 import Data.Maybe
-import Data.Monoid
 import Data.Version
 import Distribution.Compiler
 import Distribution.PackageDescription hiding ( options )

--- a/src/Cabal2Spec.hs
+++ b/src/Cabal2Spec.hs
@@ -2,7 +2,7 @@ module Cabal2Spec ( cabal2spec, createSpecFile, ForceBinary, RunTests, Copyright
 
 import Control.Monad
 import Data.Char
-import Data.List
+import Data.List ( delete, nub, sort, (\\), inits, intersect, isPrefixOf, groupBy )
 import Data.Time.Clock
 import Data.Time.Format
 import Distribution.Compiler

--- a/src/Cabal2Spec.hs
+++ b/src/Cabal2Spec.hs
@@ -160,6 +160,7 @@ createSpecFile specFile pkgDesc forceBinary runTests flagAssignment copyrightYea
   putHdr "Source0" $ "https://hackage.haskell.org/package/" ++ pkg_name ++ "-%{version}/" ++ pkg_name ++ "-%{version}.tar.gz"
   when (revision /= "0") $
     putHdr "Source1" $ "https://hackage.haskell.org/package/" ++ pkg_name ++ "-%{version}/revision/" ++ revision ++ ".cabal#/" ++ pkg_name ++ ".cabal"
+  putHdr "ExcludeArch" "%{ix86}"
 
   let fixedDeps = ["ghc-Cabal-devel", "ghc-rpm-macros"]
   let alldeps = sort $ fixedDeps ++ deps ++ tools ++ clibs ++ pkgcfgs ++ ["pkgconfig" | not (null pkgcfgs)]

--- a/test/golden-test-cases/ChasingBottoms.spec.golden
+++ b/test/golden-test-cases/ChasingBottoms.spec.golden
@@ -25,6 +25,7 @@ Summary:        For testing partial and infinite values
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/Clipboard.spec.golden
+++ b/test/golden-test-cases/Clipboard.spec.golden
@@ -24,6 +24,7 @@ Summary:        System clipboard interface
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-X11-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/FenwickTree.spec.golden
+++ b/test/golden-test-cases/FenwickTree.spec.golden
@@ -25,6 +25,7 @@ Summary:        Data structure for fast query and update of cumulative sums
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/GPipe-GLFW.spec.golden
+++ b/test/golden-test-cases/GPipe-GLFW.spec.golden
@@ -24,6 +24,7 @@ Summary:        GLFW OpenGL context creation for GPipe
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-GLFW-b-devel
 BuildRequires:  ghc-GPipe-devel

--- a/test/golden-test-cases/GenericPretty.spec.golden
+++ b/test/golden-test-cases/GenericPretty.spec.golden
@@ -24,6 +24,7 @@ Summary:        A generic, derivable, haskell pretty printer
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-pretty-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/HPDF.spec.golden
+++ b/test/golden-test-cases/HPDF.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generation of PDF documents
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-base64-bytestring-devel

--- a/test/golden-test-cases/HTF.spec.golden
+++ b/test/golden-test-cases/HTF.spec.golden
@@ -25,6 +25,7 @@ Summary:        The Haskell Test Framework
 License:        LGPL-2.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-Diff-devel

--- a/test/golden-test-cases/HTTP.spec.golden
+++ b/test/golden-test-cases/HTTP.spec.golden
@@ -25,6 +25,7 @@ Summary:        A library for client-side HTTP
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/Hclip.spec.golden
+++ b/test/golden-test-cases/Hclip.spec.golden
@@ -24,6 +24,7 @@ Summary:        A small cross-platform library for reading and modifying the sys
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-process-devel

--- a/test/golden-test-cases/MissingH.spec.golden
+++ b/test/golden-test-cases/MissingH.spec.golden
@@ -25,6 +25,7 @@ Summary:        Large utility library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-HUnit-devel
 BuildRequires:  ghc-array-devel

--- a/test/golden-test-cases/ObjectName.spec.golden
+++ b/test/golden-test-cases/ObjectName.spec.golden
@@ -24,6 +24,7 @@ Summary:        Explicitly handled object names
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-transformers-devel

--- a/test/golden-test-cases/Only.spec.golden
+++ b/test/golden-test-cases/Only.spec.golden
@@ -24,6 +24,7 @@ Summary:        The 1-tuple type or single-value "collection"
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/QuasiText.spec.golden
+++ b/test/golden-test-cases/QuasiText.spec.golden
@@ -24,6 +24,7 @@ Summary:        A QuasiQuoter for Text
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-haskell-src-meta-devel

--- a/test/golden-test-cases/QuickCheck.spec.golden
+++ b/test/golden-test-cases/QuickCheck.spec.golden
@@ -24,6 +24,7 @@ Summary:        Automatic testing of Haskell programs
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/ReadArgs.spec.golden
+++ b/test/golden-test-cases/ReadArgs.spec.golden
@@ -25,6 +25,7 @@ Summary:        Simple command line argument parsing
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-system-filepath-devel

--- a/test/golden-test-cases/SHA.spec.golden
+++ b/test/golden-test-cases/SHA.spec.golden
@@ -25,6 +25,7 @@ Summary:        Implementations of the SHA suite of message digest functions
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-binary-devel

--- a/test/golden-test-cases/Strafunski-StrategyLib.spec.golden
+++ b/test/golden-test-cases/Strafunski-StrategyLib.spec.golden
@@ -24,6 +24,7 @@ Summary:        Library for strategic programming
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-directory-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/accelerate-fftw.spec.golden
+++ b/test/golden-test-cases/accelerate-fftw.spec.golden
@@ -24,6 +24,7 @@ Summary:        Accelerate frontend to the FFTW library (Fourier transform)
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-accelerate-devel
 BuildRequires:  ghc-accelerate-io-devel

--- a/test/golden-test-cases/accelerate.spec.golden
+++ b/test/golden-test-cases/accelerate.spec.golden
@@ -24,6 +24,7 @@ Summary:        An embedded language for accelerated array processing
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-wl-pprint-devel
 BuildRequires:  ghc-base-orphans-devel

--- a/test/golden-test-cases/active.spec.golden
+++ b/test/golden-test-cases/active.spec.golden
@@ -25,6 +25,7 @@ Summary:        Abstractions for animation
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-lens-devel
 BuildRequires:  ghc-linear-devel

--- a/test/golden-test-cases/adjunctions.spec.golden
+++ b/test/golden-test-cases/adjunctions.spec.golden
@@ -24,6 +24,7 @@ Summary:        Adjunctions and representable functors
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-comonad-devel

--- a/test/golden-test-cases/aeson-diff.spec.golden
+++ b/test/golden-test-cases/aeson-diff.spec.golden
@@ -25,6 +25,7 @@ Summary:        Extract and apply patches to JSON documents
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/aeson-pretty.spec.golden
+++ b/test/golden-test-cases/aeson-pretty.spec.golden
@@ -24,6 +24,7 @@ Summary:        JSON pretty-printing library and command-line tool
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/algebraic-graphs.spec.golden
+++ b/test/golden-test-cases/algebraic-graphs.spec.golden
@@ -25,6 +25,7 @@ Summary:        A library for algebraic graph construction and transformation
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/amazonka-cloudtrail.spec.golden
+++ b/test/golden-test-cases/amazonka-cloudtrail.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon CloudTrail SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-cloudwatch-logs.spec.golden
+++ b/test/golden-test-cases/amazonka-cloudwatch-logs.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon CloudWatch Logs SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-codedeploy.spec.golden
+++ b/test/golden-test-cases/amazonka-codedeploy.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon CodeDeploy SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-cognito-idp.spec.golden
+++ b/test/golden-test-cases/amazonka-cognito-idp.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon Cognito Identity Provider SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-ecs.spec.golden
+++ b/test/golden-test-cases/amazonka-ecs.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon EC2 Container Service SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-kms.spec.golden
+++ b/test/golden-test-cases/amazonka-kms.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon Key Management Service SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-lightsail.spec.golden
+++ b/test/golden-test-cases/amazonka-lightsail.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon Lightsail SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-route53-domains.spec.golden
+++ b/test/golden-test-cases/amazonka-route53-domains.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon Route 53 Domains SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/amazonka-waf.spec.golden
+++ b/test/golden-test-cases/amazonka-waf.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon WAF SDK
 License:        MPL-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/api-field-json-th.spec.golden
+++ b/test/golden-test-cases/api-field-json-th.spec.golden
@@ -25,6 +25,7 @@ Summary:        Option of aeson's deriveJSON
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-lens-devel

--- a/test/golden-test-cases/app-settings.spec.golden
+++ b/test/golden-test-cases/app-settings.spec.golden
@@ -25,6 +25,7 @@ Summary:        A library to manage application settings (INI file-like)
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/apply-refact.spec.golden
+++ b/test/golden-test-cases/apply-refact.spec.golden
@@ -25,6 +25,7 @@ Summary:        Perform refactorings specified by the refact library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/async.spec.golden
+++ b/test/golden-test-cases/async.spec.golden
@@ -25,6 +25,7 @@ Summary:        Run IO operations asynchronously and wait for their results
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-stm-devel

--- a/test/golden-test-cases/attoparsec-expr.spec.golden
+++ b/test/golden-test-cases/attoparsec-expr.spec.golden
@@ -24,6 +24,7 @@ Summary:        Port of parsec's expression parser to attoparsec
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/attoparsec-time.spec.golden
+++ b/test/golden-test-cases/attoparsec-time.spec.golden
@@ -25,6 +25,7 @@ Summary:        Attoparsec parsers of time
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-base-prelude-devel

--- a/test/golden-test-cases/avers-server.spec.golden
+++ b/test/golden-test-cases/avers-server.spec.golden
@@ -24,6 +24,7 @@ Summary:        Server implementation of the Avers API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-avers-api-devel

--- a/test/golden-test-cases/aws.spec.golden
+++ b/test/golden-test-cases/aws.spec.golden
@@ -25,6 +25,7 @@ Summary:        Amazon Web Services (AWS) for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/bbdb.spec.golden
+++ b/test/golden-test-cases/bbdb.spec.golden
@@ -25,6 +25,7 @@ Summary:        Ability to read, write, and modify BBDB files
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-parsec-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/benchpress.spec.golden
+++ b/test/golden-test-cases/benchpress.spec.golden
@@ -24,6 +24,7 @@ Summary:        Micro-benchmarking with detailed statistics
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/binary-bits.spec.golden
+++ b/test/golden-test-cases/binary-bits.spec.golden
@@ -25,6 +25,7 @@ Summary:        Bit parsing/writing on top of binary
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/binary-tagged.spec.golden
+++ b/test/golden-test-cases/binary-tagged.spec.golden
@@ -25,6 +25,7 @@ Summary:        Tagged binary serialisation
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-SHA-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/bindings-uname.spec.golden
+++ b/test/golden-test-cases/bindings-uname.spec.golden
@@ -24,6 +24,7 @@ Summary:        Low-level binding to POSIX uname(3)
 License:        SUSE-Public-Domain
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/bioalign.spec.golden
+++ b/test/golden-test-cases/bioalign.spec.golden
@@ -24,6 +24,7 @@ Summary:        Data structures and helper functions for calculating alignments
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-biocore-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/bits.spec.golden
+++ b/test/golden-test-cases/bits.spec.golden
@@ -25,6 +25,7 @@ Summary:        Various bit twiddling and bitwise serialization primitives
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytes-devel
 BuildRequires:  ghc-cabal-doctest-devel

--- a/test/golden-test-cases/blank-canvas.spec.golden
+++ b/test/golden-test-cases/blank-canvas.spec.golden
@@ -25,6 +25,7 @@ Summary:        HTML5 Canvas Graphics Library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-base-compat-devel

--- a/test/golden-test-cases/blaze-html.spec.golden
+++ b/test/golden-test-cases/blaze-html.spec.golden
@@ -25,6 +25,7 @@ Summary:        A blazingly fast HTML combinator library for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-builder-devel
 BuildRequires:  ghc-blaze-markup-devel

--- a/test/golden-test-cases/blaze-markup.spec.golden
+++ b/test/golden-test-cases/blaze-markup.spec.golden
@@ -25,6 +25,7 @@ Summary:        A blazingly fast markup combinator library for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-builder-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/blaze-svg.spec.golden
+++ b/test/golden-test-cases/blaze-svg.spec.golden
@@ -24,6 +24,7 @@ Summary:        SVG combinator library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-markup-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/blosum.spec.golden
+++ b/test/golden-test-cases/blosum.spec.golden
@@ -24,6 +24,7 @@ Summary:        BLOSUM generator
 License:        GPL-2.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/boomerang.spec.golden
+++ b/test/golden-test-cases/boomerang.spec.golden
@@ -24,6 +24,7 @@ Summary:        Library for invertible parsing and printing
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/boxes.spec.golden
+++ b/test/golden-test-cases/boxes.spec.golden
@@ -25,6 +25,7 @@ Summary:        2D text pretty-printing library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-split-devel

--- a/test/golden-test-cases/brittany.spec.golden
+++ b/test/golden-test-cases/brittany.spec.golden
@@ -25,6 +25,7 @@ Summary:        Haskell source code formatter
 License:        AGPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/broadcast-chan.spec.golden
+++ b/test/golden-test-cases/broadcast-chan.spec.golden
@@ -24,6 +24,7 @@ Summary:        Broadcast channel type that avoids 0 reader space leaks
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/butcher.spec.golden
+++ b/test/golden-test-cases/butcher.spec.golden
@@ -24,6 +24,7 @@ Summary:        Chops a command or program invocation into digestable pieces
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bifunctors-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/bzlib.spec.golden
+++ b/test/golden-test-cases/bzlib.spec.golden
@@ -24,6 +24,7 @@ Summary:        Compression and decompression in the bzip2 format
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/case-insensitive.spec.golden
+++ b/test/golden-test-cases/case-insensitive.spec.golden
@@ -25,6 +25,7 @@ Summary:        Case insensitive string comparison
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/cassava-conduit.spec.golden
+++ b/test/golden-test-cases/cassava-conduit.spec.golden
@@ -25,6 +25,7 @@ Summary:        Conduit interface for cassava package
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bifunctors-devel

--- a/test/golden-test-cases/cassette.spec.golden
+++ b/test/golden-test-cases/cassette.spec.golden
@@ -24,6 +24,7 @@ Summary:        A combinator library for simultaneously defining parsers and pre
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/cereal-text.spec.golden
+++ b/test/golden-test-cases/cereal-text.spec.golden
@@ -24,6 +24,7 @@ Summary:        Data.Text instances for the cereal serialization library
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-cereal-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/cheapskate.spec.golden
+++ b/test/golden-test-cases/cheapskate.spec.golden
@@ -24,6 +24,7 @@ Summary:        Experimental markdown processor
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-html-devel

--- a/test/golden-test-cases/chell.spec.golden
+++ b/test/golden-test-cases/chell.spec.golden
@@ -24,6 +24,7 @@ Summary:        A simple and intuitive library for automated testing
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-terminal-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/clumpiness.spec.golden
+++ b/test/golden-test-cases/clumpiness.spec.golden
@@ -24,6 +24,7 @@ Summary:        Calculate the clumpiness of leaf properties in a tree
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/code-page.spec.golden
+++ b/test/golden-test-cases/code-page.spec.golden
@@ -24,6 +24,7 @@ Summary:        Windows code page library for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/colorize-haskell.spec.golden
+++ b/test/golden-test-cases/colorize-haskell.spec.golden
@@ -24,6 +24,7 @@ Summary:        Highligt Haskell source
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-terminal-devel
 BuildRequires:  ghc-haskell-lexer-devel

--- a/test/golden-test-cases/countable.spec.golden
+++ b/test/golden-test-cases/countable.spec.golden
@@ -25,6 +25,7 @@ Summary:        Countable, Searchable, Finite, Empty classes
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/cpu.spec.golden
+++ b/test/golden-test-cases/cpu.spec.golden
@@ -24,6 +24,7 @@ Summary:        Cpu information and properties helpers
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/criterion.spec.golden
+++ b/test/golden-test-cases/criterion.spec.golden
@@ -25,6 +25,7 @@ Summary:        Robust, reliable performance measurement and analysis
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-Glob-devel

--- a/test/golden-test-cases/crypt-sha512.spec.golden
+++ b/test/golden-test-cases/crypt-sha512.spec.golden
@@ -25,6 +25,7 @@ Summary:        Pure Haskell implelementation for GNU SHA512 crypt algorithm
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/crypto-random-api.spec.golden
+++ b/test/golden-test-cases/crypto-random-api.spec.golden
@@ -24,6 +24,7 @@ Summary:        Simple random generators API for cryptography related code
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-entropy-devel

--- a/test/golden-test-cases/csv.spec.golden
+++ b/test/golden-test-cases/csv.spec.golden
@@ -24,6 +24,7 @@ Summary:        CSV loader and dumper
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-filepath-devel
 BuildRequires:  ghc-parsec-devel

--- a/test/golden-test-cases/data-accessor.spec.golden
+++ b/test/golden-test-cases/data-accessor.spec.golden
@@ -24,6 +24,7 @@ Summary:        Utilities for accessing and manipulating fields of records
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/data-default-instances-containers.spec.golden
+++ b/test/golden-test-cases/data-default-instances-containers.spec.golden
@@ -24,6 +24,7 @@ Summary:        Default instances for types in containers
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-data-default-class-devel

--- a/test/golden-test-cases/data-endian.spec.golden
+++ b/test/golden-test-cases/data-endian.spec.golden
@@ -24,6 +24,7 @@ Summary:        Endian-sensitive data
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/data-msgpack.spec.golden
+++ b/test/golden-test-cases/data-msgpack.spec.golden
@@ -25,6 +25,7 @@ Summary:        A Haskell implementation of MessagePack
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel

--- a/test/golden-test-cases/data-serializer.spec.golden
+++ b/test/golden-test-cases/data-serializer.spec.golden
@@ -25,6 +25,7 @@ Summary:        Common API for serialization libraries
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/deque.spec.golden
+++ b/test/golden-test-cases/deque.spec.golden
@@ -24,6 +24,7 @@ Summary:        Double-ended queue
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/dhall-bash.spec.golden
+++ b/test/golden-test-cases/dhall-bash.spec.golden
@@ -24,6 +24,7 @@ Summary:        Compile Dhall to Bash
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/diagrams-solve.spec.golden
+++ b/test/golden-test-cases/diagrams-solve.spec.golden
@@ -25,6 +25,7 @@ Summary:        Pure Haskell solver routines used by diagrams
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/discrimination.spec.golden
+++ b/test/golden-test-cases/discrimination.spec.golden
@@ -24,6 +24,7 @@ Summary:        Fast generic linear-time sorting, joins and container constructi
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/dotenv.spec.golden
+++ b/test/golden-test-cases/dotenv.spec.golden
@@ -25,6 +25,7 @@ Summary:        Loads environment variables from dotenv files
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-base-compat-devel

--- a/test/golden-test-cases/dotnet-timespan.spec.golden
+++ b/test/golden-test-cases/dotnet-timespan.spec.golden
@@ -24,6 +24,7 @@ Summary:        .NET TimeSpan
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/dpor.spec.golden
+++ b/test/golden-test-cases/dpor.spec.golden
@@ -24,6 +24,7 @@ Summary:        A generic implementation of dynamic partial-order reduction (DPO
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/drawille.spec.golden
+++ b/test/golden-test-cases/drawille.spec.golden
@@ -25,6 +25,7 @@ Summary:        A port of asciimoo's drawille to haskell
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/drifter-postgresql.spec.golden
+++ b/test/golden-test-cases/drifter-postgresql.spec.golden
@@ -25,6 +25,7 @@ Summary:        PostgreSQL support for the drifter schema migration tool
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-drifter-devel

--- a/test/golden-test-cases/ede.spec.golden
+++ b/test/golden-test-cases/ede.spec.golden
@@ -25,6 +25,7 @@ Summary:        Templating language with similar syntax and features to Liquid o
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-ansi-wl-pprint-devel

--- a/test/golden-test-cases/ekg-cloudwatch.spec.golden
+++ b/test/golden-test-cases/ekg-cloudwatch.spec.golden
@@ -24,6 +24,7 @@ Summary:        An ekg backend for Amazon Cloudwatch
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-amazonka-cloudwatch-devel
 BuildRequires:  ghc-amazonka-core-devel

--- a/test/golden-test-cases/emailaddress.spec.golden
+++ b/test/golden-test-cases/emailaddress.spec.golden
@@ -25,6 +25,7 @@ Summary:        Wrapper around email-validate library adding instances for commo
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bifunctors-devel

--- a/test/golden-test-cases/envelope.spec.golden
+++ b/test/golden-test-cases/envelope.spec.golden
@@ -25,6 +25,7 @@ Summary:        Defines generic 'Envelope' type to wrap reponses from a JSON API
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-http-api-data-devel

--- a/test/golden-test-cases/eventful-sqlite.spec.golden
+++ b/test/golden-test-cases/eventful-sqlite.spec.golden
@@ -25,6 +25,7 @@ Summary:        SQLite implementations for eventful
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/exact-pi.spec.golden
+++ b/test/golden-test-cases/exact-pi.spec.golden
@@ -24,6 +24,7 @@ Summary:        Exact rational multiples of pi (and integer powers of pi)
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-numtype-dk-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/expiring-cache-map.spec.golden
+++ b/test/golden-test-cases/expiring-cache-map.spec.golden
@@ -25,6 +25,7 @@ Summary:        General purpose simple caching
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/explicit-exception.spec.golden
+++ b/test/golden-test-cases/explicit-exception.spec.golden
@@ -24,6 +24,7 @@ Summary:        Exceptions which are explicit in the type signature
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/fdo-notify.spec.golden
+++ b/test/golden-test-cases/fdo-notify.spec.golden
@@ -24,6 +24,7 @@ Summary:        Desktop Notifications client
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-dbus-devel

--- a/test/golden-test-cases/fgl.spec.golden
+++ b/test/golden-test-cases/fgl.spec.golden
@@ -25,6 +25,7 @@ Summary:        Martin Erwig's Functional Graph Library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/file-modules.spec.golden
+++ b/test/golden-test-cases/file-modules.spec.golden
@@ -24,6 +24,7 @@ Summary:        Takes a Haskell source-code file and outputs its modules
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-MissingH-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/fingertree.spec.golden
+++ b/test/golden-test-cases/fingertree.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generic finger-tree structure, with example instances
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/fixed-vector.spec.golden
+++ b/test/golden-test-cases/fixed-vector.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generic vectors with statically known size
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-primitive-devel

--- a/test/golden-test-cases/fixed.spec.golden
+++ b/test/golden-test-cases/fixed.spec.golden
@@ -24,6 +24,7 @@ Summary:        Signed 15.16 precision fixed point arithmetic
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/foundation.spec.golden
+++ b/test/golden-test-cases/foundation.spec.golden
@@ -25,6 +25,7 @@ Summary:        Alternative prelude with batteries and no dependencies
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-basement-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/frisby.spec.golden
+++ b/test/golden-test-cases/frisby.spec.golden
@@ -24,6 +24,7 @@ Summary:        Linear time composable parser for PEG grammars
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/funcmp.spec.golden
+++ b/test/golden-test-cases/funcmp.spec.golden
@@ -24,6 +24,7 @@ Summary:        Functional MetaPost
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-filepath-devel
 BuildRequires:  ghc-process-devel

--- a/test/golden-test-cases/functor-classes-compat.spec.golden
+++ b/test/golden-test-cases/functor-classes-compat.spec.golden
@@ -24,6 +24,7 @@ Summary:        Data.Functor.Classes instances for core packages
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/general-games.spec.golden
+++ b/test/golden-test-cases/general-games.spec.golden
@@ -25,6 +25,7 @@ Summary:        Library supporting simulation of a number of games
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-MonadRandom-devel
 BuildRequires:  ghc-monad-loops-devel

--- a/test/golden-test-cases/generic-lens.spec.golden
+++ b/test/golden-test-cases/generic-lens.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generic data-structure operations exposed as lenses
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-profunctors-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/genvalidity-aeson.spec.golden
+++ b/test/golden-test-cases/genvalidity-aeson.spec.golden
@@ -25,6 +25,7 @@ Summary:        GenValidity support for aeson
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/genvalidity-hspec-aeson.spec.golden
+++ b/test/golden-test-cases/genvalidity-hspec-aeson.spec.golden
@@ -25,6 +25,7 @@ Summary:        Standard spec's for aeson-related instances
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/genvalidity-hspec-binary.spec.golden
+++ b/test/golden-test-cases/genvalidity-hspec-binary.spec.golden
@@ -25,6 +25,7 @@ Summary:        Standard spec's for binary-related Instances
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-binary-devel

--- a/test/golden-test-cases/genvalidity-scientific.spec.golden
+++ b/test/golden-test-cases/genvalidity-scientific.spec.golden
@@ -25,6 +25,7 @@ Summary:        GenValidity support for Scientific
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-genvalidity-devel

--- a/test/golden-test-cases/genvalidity-uuid.spec.golden
+++ b/test/golden-test-cases/genvalidity-uuid.spec.golden
@@ -25,6 +25,7 @@ Summary:        GenValidity support for UUID
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-genvalidity-devel

--- a/test/golden-test-cases/ghc-syb-utils.spec.golden
+++ b/test/golden-test-cases/ghc-syb-utils.spec.golden
@@ -25,6 +25,7 @@ Summary:        Scrap Your Boilerplate utilities for the GHC API
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ghc-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/ghcid.spec.golden
+++ b/test/golden-test-cases/ghcid.spec.golden
@@ -25,6 +25,7 @@ Summary:        GHCi based bare bones IDE
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-terminal-devel
 BuildRequires:  ghc-cmdargs-devel

--- a/test/golden-test-cases/giphy-api.spec.golden
+++ b/test/golden-test-cases/giphy-api.spec.golden
@@ -25,6 +25,7 @@ Summary:        Giphy HTTP API wrapper and CLI search tool
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/github.spec.golden
+++ b/test/golden-test-cases/github.spec.golden
@@ -25,6 +25,7 @@ Summary:        Access to the GitHub API, v3
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-compat-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/gl.spec.golden
+++ b/test/golden-test-cases/gl.spec.golden
@@ -24,6 +24,7 @@ Summary:        Complete OpenGL raw bindings
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  Mesa-libGL-devel
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/gogol-adexchange-buyer.spec.golden
+++ b/test/golden-test-cases/gogol-adexchange-buyer.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Ad Exchange Buyer SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-admin-emailmigration.spec.golden
+++ b/test/golden-test-cases/gogol-admin-emailmigration.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Email Migration API v2 SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-affiliates.spec.golden
+++ b/test/golden-test-cases/gogol-affiliates.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Affiliate Network SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-apps-tasks.spec.golden
+++ b/test/golden-test-cases/gogol-apps-tasks.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Tasks SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-appstate.spec.golden
+++ b/test/golden-test-cases/gogol-appstate.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google App State SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-blogger.spec.golden
+++ b/test/golden-test-cases/gogol-blogger.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Blogger SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-datastore.spec.golden
+++ b/test/golden-test-cases/gogol-datastore.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Cloud Datastore SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-dfareporting.spec.golden
+++ b/test/golden-test-cases/gogol-dfareporting.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google DCM/DFA Reporting And Trafficking SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-firebase-rules.spec.golden
+++ b/test/golden-test-cases/gogol-firebase-rules.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Firebase Rules SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-gmail.spec.golden
+++ b/test/golden-test-cases/gogol-gmail.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Gmail SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-kgsearch.spec.golden
+++ b/test/golden-test-cases/gogol-kgsearch.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Knowledge Graph Search SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-maps-engine.spec.golden
+++ b/test/golden-test-cases/gogol-maps-engine.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Maps Engine SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-plus.spec.golden
+++ b/test/golden-test-cases/gogol-plus.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google + SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-resourceviews.spec.golden
+++ b/test/golden-test-cases/gogol-resourceviews.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Compute Engine Instance Groups SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-translate.spec.golden
+++ b/test/golden-test-cases/gogol-translate.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Translate SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-webmaster-tools.spec.golden
+++ b/test/golden-test-cases/gogol-webmaster-tools.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google Search Console SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/gogol-youtube.spec.golden
+++ b/test/golden-test-cases/gogol-youtube.spec.golden
@@ -24,6 +24,7 @@ Summary:        Google YouTube Data SDK
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-gogol-core-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/groundhog-mysql.spec.golden
+++ b/test/golden-test-cases/groundhog-mysql.spec.golden
@@ -24,6 +24,7 @@ Summary:        MySQL backend for the groundhog library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/gsasl.spec.golden
+++ b/test/golden-test-cases/gsasl.spec.golden
@@ -24,6 +24,7 @@ Summary:        Bindings for GNU libgsasl
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/hOpenPGP.spec.golden
+++ b/test/golden-test-cases/hOpenPGP.spec.golden
@@ -25,6 +25,7 @@ Summary:        Native Haskell implementation of OpenPGP (RFC4880)
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/hPDB-examples.spec.golden
+++ b/test/golden-test-cases/hPDB-examples.spec.golden
@@ -24,6 +24,7 @@ Summary:        Examples for hPDB library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-AC-Vector-devel
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-GLUT-devel

--- a/test/golden-test-cases/haddock-library.spec.golden
+++ b/test/golden-test-cases/haddock-library.spec.golden
@@ -26,6 +26,7 @@ Summary:        Library exposing some functionality of Haddock
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/hakyll.spec.golden
+++ b/test/golden-test-cases/hakyll.spec.golden
@@ -25,6 +25,7 @@ Summary:        A static website compiler library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel

--- a/test/golden-test-cases/happstack-hsp.spec.golden
+++ b/test/golden-test-cases/happstack-hsp.spec.golden
@@ -24,6 +24,7 @@ Summary:        Support for using HSP templates in Happstack
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-happstack-server-devel

--- a/test/golden-test-cases/happy.spec.golden
+++ b/test/golden-test-cases/happy.spec.golden
@@ -24,6 +24,7 @@ Summary:        Happy is a parser generator for Haskell
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/harp.spec.golden
+++ b/test/golden-test-cases/harp.spec.golden
@@ -24,6 +24,7 @@ Summary:        HaRP allows pattern-matching with regular expressions
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/hashtables.spec.golden
+++ b/test/golden-test-cases/hashtables.spec.golden
@@ -24,6 +24,7 @@ Summary:        Mutable hash tables in the ST monad
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hashable-devel
 BuildRequires:  ghc-primitive-devel

--- a/test/golden-test-cases/haskell-tools-debug.spec.golden
+++ b/test/golden-test-cases/haskell-tools-debug.spec.golden
@@ -24,6 +24,7 @@ Summary:        Debugging Tools for Haskell-tools
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-filepath-devel

--- a/test/golden-test-cases/haskell-tools-rewrite.spec.golden
+++ b/test/golden-test-cases/haskell-tools-rewrite.spec.golden
@@ -25,6 +25,7 @@ Summary:        Facilities for generating new parts of the Haskell-Tools AST
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-ghc-devel

--- a/test/golden-test-cases/hasql.spec.golden
+++ b/test/golden-test-cases/hasql.spec.golden
@@ -25,6 +25,7 @@ Summary:        An efficient PostgreSQL driver and a flexible mapping API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-base-prelude-devel

--- a/test/golden-test-cases/hformat.spec.golden
+++ b/test/golden-test-cases/hformat.spec.golden
@@ -25,6 +25,7 @@ Summary:        Simple Haskell formatting
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-terminal-devel
 BuildRequires:  ghc-base-unicode-symbols-devel

--- a/test/golden-test-cases/highlighting-kate.spec.golden
+++ b/test/golden-test-cases/highlighting-kate.spec.golden
@@ -25,6 +25,7 @@ Summary:        Syntax highlighting
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-html-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/hit.spec.golden
+++ b/test/golden-test-cases/hit.spec.golden
@@ -25,6 +25,7 @@ Summary:        Git operations in haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-byteable-devel

--- a/test/golden-test-cases/hjson.spec.golden
+++ b/test/golden-test-cases/hjson.spec.golden
@@ -24,6 +24,7 @@ Summary:        JSON parsing library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-parsec-devel

--- a/test/golden-test-cases/hmpfr.spec.golden
+++ b/test/golden-test-cases/hmpfr.spec.golden
@@ -24,6 +24,7 @@ Summary:        Haskell binding to the MPFR library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  mpfr-devel

--- a/test/golden-test-cases/hoogle.spec.golden
+++ b/test/golden-test-cases/hoogle.spec.golden
@@ -24,6 +24,7 @@ Summary:        Haskell API Search
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel

--- a/test/golden-test-cases/hostname-validate.spec.golden
+++ b/test/golden-test-cases/hostname-validate.spec.golden
@@ -24,6 +24,7 @@ Summary:        Validate hostnames e.g. localhost or foo.co.uk
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/hsinstall.spec.golden
+++ b/test/golden-test-cases/hsinstall.spec.golden
@@ -24,6 +24,7 @@ Summary:        Install Haskell software
 License:        ISC
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/hstatsd.spec.golden
+++ b/test/golden-test-cases/hstatsd.spec.golden
@@ -24,6 +24,7 @@ Summary:        Quick and dirty statsd interface
 License:        SUSE-Public-Domain
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/hsx-jmacro.spec.golden
+++ b/test/golden-test-cases/hsx-jmacro.spec.golden
@@ -24,6 +24,7 @@ Summary:        Hsp+jmacro support
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hsp-devel
 BuildRequires:  ghc-jmacro-devel

--- a/test/golden-test-cases/hsyslog.spec.golden
+++ b/test/golden-test-cases/hsyslog.spec.golden
@@ -25,6 +25,7 @@ Summary:        FFI interface to syslog(3) from POSIX.1-2001
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-cabal-doctest-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/htoml.spec.golden
+++ b/test/golden-test-cases/htoml.spec.golden
@@ -25,6 +25,7 @@ Summary:        Parser for TOML files
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/http-conduit.spec.golden
+++ b/test/golden-test-cases/http-conduit.spec.golden
@@ -25,6 +25,7 @@ Summary:        HTTP client package with conduit interface and HTTPS support
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/http-link-header.spec.golden
+++ b/test/golden-test-cases/http-link-header.spec.golden
@@ -25,6 +25,7 @@ Summary:        A parser and writer for the HTTP Link header as specified in RFC
 License:        SUSE-Public-Domain
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-bytestring-conversion-devel

--- a/test/golden-test-cases/http-media.spec.golden
+++ b/test/golden-test-cases/http-media.spec.golden
@@ -25,6 +25,7 @@ Summary:        Processing HTTP Content-Type and Accept headers
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-case-insensitive-devel

--- a/test/golden-test-cases/hxt-charproperties.spec.golden
+++ b/test/golden-test-cases/hxt-charproperties.spec.golden
@@ -24,6 +24,7 @@ Summary:        Character properties and classes for XML and Unicode
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/hxt-expat.spec.golden
+++ b/test/golden-test-cases/hxt-expat.spec.golden
@@ -24,6 +24,7 @@ Summary:        Expat parser for HXT
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-hexpat-devel

--- a/test/golden-test-cases/hxt-tagsoup.spec.golden
+++ b/test/golden-test-cases/hxt-tagsoup.spec.golden
@@ -24,6 +24,7 @@ Summary:        TagSoup parser for HXT
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hxt-charproperties-devel
 BuildRequires:  ghc-hxt-devel

--- a/test/golden-test-cases/iconv.spec.golden
+++ b/test/golden-test-cases/iconv.spec.golden
@@ -24,6 +24,7 @@ Summary:        String encoding conversion
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/incremental-parser.spec.golden
+++ b/test/golden-test-cases/incremental-parser.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generic parser library capable of providing partial results from
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-monoid-subclasses-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/indentation-core.spec.golden
+++ b/test/golden-test-cases/indentation-core.spec.golden
@@ -24,6 +24,7 @@ Summary:        Indentation sensitive parsing combinators core library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/indentation-parsec.spec.golden
+++ b/test/golden-test-cases/indentation-parsec.spec.golden
@@ -25,6 +25,7 @@ Summary:        Indentation sensitive parsing combinators for Parsec
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-indentation-core-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/inline-c-cpp.spec.golden
+++ b/test/golden-test-cases/inline-c-cpp.spec.golden
@@ -25,6 +25,7 @@ Summary:        Lets you embed C++ code into Haskell
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-inline-c-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/integer-logarithms.spec.golden
+++ b/test/golden-test-cases/integer-logarithms.spec.golden
@@ -25,6 +25,7 @@ Summary:        Integer logarithms
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/intero.spec.golden
+++ b/test/golden-test-cases/intero.spec.golden
@@ -24,6 +24,7 @@ Summary:        Complete interactive development program for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/invariant.spec.golden
+++ b/test/golden-test-cases/invariant.spec.golden
@@ -25,6 +25,7 @@ Summary:        Haskell98 invariant functors
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-StateVar-devel
 BuildRequires:  ghc-array-devel

--- a/test/golden-test-cases/io-machine.spec.golden
+++ b/test/golden-test-cases/io-machine.spec.golden
@@ -24,6 +24,7 @@ Summary:        Easy I/O model to learn IO monad
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-time-devel

--- a/test/golden-test-cases/io-streams-haproxy.spec.golden
+++ b/test/golden-test-cases/io-streams-haproxy.spec.golden
@@ -25,6 +25,7 @@ Summary:        HAProxy protocol 1.5 support for io-streams
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/ip.spec.golden
+++ b/test/golden-test-cases/ip.spec.golden
@@ -25,6 +25,7 @@ Summary:        Library for IP and MAC addresses
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/iso639.spec.golden
+++ b/test/golden-test-cases/iso639.spec.golden
@@ -24,6 +24,7 @@ Summary:        ISO-639-1 language codes
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/iso8601-time.spec.golden
+++ b/test/golden-test-cases/iso8601-time.spec.golden
@@ -25,6 +25,7 @@ Summary:        Convert to/from the ISO 8601 time format
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-time-devel

--- a/test/golden-test-cases/jmacro-rpc-happstack.spec.golden
+++ b/test/golden-test-cases/jmacro-rpc-happstack.spec.golden
@@ -24,6 +24,7 @@ Summary:        Happstack backend for jmacro-rpc
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-blaze-html-devel

--- a/test/golden-test-cases/jmacro-rpc.spec.golden
+++ b/test/golden-test-cases/jmacro-rpc.spec.golden
@@ -24,6 +24,7 @@ Summary:        JSON-RPC clients and servers using JMacro, and evented client-se
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/jose.spec.golden
+++ b/test/golden-test-cases/jose.spec.golden
@@ -25,6 +25,7 @@ Summary:        Javascript Object Signing and Encryption and JSON Web Token libr
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel

--- a/test/golden-test-cases/katip-elasticsearch.spec.golden
+++ b/test/golden-test-cases/katip-elasticsearch.spec.golden
@@ -25,6 +25,7 @@ Summary:        ElasticSearch scribe for the Katip logging framework
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/katip.spec.golden
+++ b/test/golden-test-cases/katip.spec.golden
@@ -25,6 +25,7 @@ Summary:        A structured logging framework
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/katydid.spec.golden
+++ b/test/golden-test-cases/katydid.spec.golden
@@ -25,6 +25,7 @@ Summary:        A haskell implementation of Katydid
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/kawhi.spec.golden
+++ b/test/golden-test-cases/kawhi.spec.golden
@@ -25,6 +25,7 @@ Summary:        Stats.NBA.com library
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/kraken.spec.golden
+++ b/test/golden-test-cases/kraken.spec.golden
@@ -24,6 +24,7 @@ Summary:        Kraken.io API client
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/l10n.spec.golden
+++ b/test/golden-test-cases/l10n.spec.golden
@@ -24,6 +24,7 @@ Summary:        Enables providing localization as typeclass instances in separat
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-text-devel

--- a/test/golden-test-cases/lambdabot-social-plugins.spec.golden
+++ b/test/golden-test-cases/lambdabot-social-plugins.spec.golden
@@ -24,6 +24,7 @@ Summary:        Social plugins for Lambdabot
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/lazy-csv.spec.golden
+++ b/test/golden-test-cases/lazy-csv.spec.golden
@@ -24,6 +24,7 @@ Summary:        Efficient lazy parsers for CSV (comma-separated values)
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/lens-aeson.spec.golden
+++ b/test/golden-test-cases/lens-aeson.spec.golden
@@ -25,6 +25,7 @@ Summary:        Law-abiding lenses for aeson
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/lens.spec.golden
+++ b/test/golden-test-cases/lens.spec.golden
@@ -25,6 +25,7 @@ Summary:        Lenses, Folds and Traversals
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-base-orphans-devel

--- a/test/golden-test-cases/libgit.spec.golden
+++ b/test/golden-test-cases/libgit.spec.golden
@@ -24,6 +24,7 @@ Summary:        Simple Git Wrapper
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-process-devel

--- a/test/golden-test-cases/librato.spec.golden
+++ b/test/golden-test-cases/librato.spec.golden
@@ -24,6 +24,7 @@ Summary:        Bindings to the Librato API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/lifted-async.spec.golden
+++ b/test/golden-test-cases/lifted-async.spec.golden
@@ -25,6 +25,7 @@ Summary:        Run lifted IO operations asynchronously and wait for their resul
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-async-devel
 BuildRequires:  ghc-constraints-devel

--- a/test/golden-test-cases/lmdb.spec.golden
+++ b/test/golden-test-cases/lmdb.spec.golden
@@ -24,6 +24,7 @@ Summary:        Lightning MDB bindings
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/logging-effect-extra-file.spec.golden
+++ b/test/golden-test-cases/logging-effect-extra-file.spec.golden
@@ -24,6 +24,7 @@ Summary:        TH splices to augment log messages with file info
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-logging-effect-devel

--- a/test/golden-test-cases/lucid.spec.golden
+++ b/test/golden-test-cases/lucid.spec.golden
@@ -25,6 +25,7 @@ Summary:        Clear to write, read and edit DSL for HTML
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-builder-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/mainland-pretty.spec.golden
+++ b/test/golden-test-cases/mainland-pretty.spec.golden
@@ -24,6 +24,7 @@ Summary:        Pretty printing designed for printing source code
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/matrices.spec.golden
+++ b/test/golden-test-cases/matrices.spec.golden
@@ -25,6 +25,7 @@ Summary:        Native matrix based on vector
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-primitive-devel

--- a/test/golden-test-cases/median-stream.spec.golden
+++ b/test/golden-test-cases/median-stream.spec.golden
@@ -25,6 +25,7 @@ Summary:        Constant-time queries for the median of a stream of numeric data
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-heap-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/megaparsec.spec.golden
+++ b/test/golden-test-cases/megaparsec.spec.golden
@@ -25,6 +25,7 @@ Summary:        Monadic parser combinators
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-case-insensitive-devel

--- a/test/golden-test-cases/mersenne-random.spec.golden
+++ b/test/golden-test-cases/mersenne-random.spec.golden
@@ -24,6 +24,7 @@ Summary:        Generate high quality pseudorandom numbers using a SIMD Fast Mer
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-old-time-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/messagepack.spec.golden
+++ b/test/golden-test-cases/messagepack.spec.golden
@@ -25,6 +25,7 @@ Summary:        Serialize instance for Message Pack Object
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-cereal-devel

--- a/test/golden-test-cases/microlens-ghc.spec.golden
+++ b/test/golden-test-cases/microlens-ghc.spec.golden
@@ -24,6 +24,7 @@ Summary:        Microlens + array, bytestring, containers, transformers
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/microlens.spec.golden
+++ b/test/golden-test-cases/microlens.spec.golden
@@ -24,6 +24,7 @@ Summary:        A tiny lens library with no dependencies. If you're writing an a
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/minio-hs.spec.golden
+++ b/test/golden-test-cases/minio-hs.spec.golden
@@ -25,6 +25,7 @@ Summary:        A Minio Haskell Library for Amazon S3 compatible cloud storage
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/mmorph.spec.golden
+++ b/test/golden-test-cases/mmorph.spec.golden
@@ -24,6 +24,7 @@ Summary:        Monad morphisms
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/mnist-idx.spec.golden
+++ b/test/golden-test-cases/mnist-idx.spec.golden
@@ -25,6 +25,7 @@ Summary:        Read and write IDX data that is used in e.g. the MNIST database
 License:        LGPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/mole.spec.golden
+++ b/test/golden-test-cases/mole.spec.golden
@@ -24,6 +24,7 @@ Summary:        A glorified string replacement tool
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-base64-bytestring-devel

--- a/test/golden-test-cases/monad-products.spec.golden
+++ b/test/golden-test-cases/monad-products.spec.golden
@@ -24,6 +24,7 @@ Summary:        Monad products
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-semigroupoids-devel

--- a/test/golden-test-cases/monadcryptorandom.spec.golden
+++ b/test/golden-test-cases/monadcryptorandom.spec.golden
@@ -24,6 +24,7 @@ Summary:        A monad for using CryptoRandomGen
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-crypto-api-devel

--- a/test/golden-test-cases/monadloc.spec.golden
+++ b/test/golden-test-cases/monadloc.spec.golden
@@ -24,6 +24,7 @@ Summary:        A class for monads which can keep a monadic call trace
 License:        SUSE-Public-Domain
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-template-haskell-devel

--- a/test/golden-test-cases/mongoDB.spec.golden
+++ b/test/golden-test-cases/mongoDB.spec.golden
@@ -25,6 +25,7 @@ Summary:        Driver (client) for MongoDB, a free, scalable, fast, document DB
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-base16-bytestring-devel

--- a/test/golden-test-cases/monoid-extras.spec.golden
+++ b/test/golden-test-cases/monoid-extras.spec.golden
@@ -24,6 +24,7 @@ Summary:        Various extra monoid-related definitions and utilities
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-groups-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/mwc-random-monad.spec.golden
+++ b/test/golden-test-cases/mwc-random-monad.spec.golden
@@ -24,6 +24,7 @@ Summary:        Monadic interface for mwc-random
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-monad-primitive-devel
 BuildRequires:  ghc-mwc-random-devel

--- a/test/golden-test-cases/mwc-random.spec.golden
+++ b/test/golden-test-cases/mwc-random.spec.golden
@@ -24,6 +24,7 @@ Summary:        Fast, high quality pseudo random number generation
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-math-functions-devel
 BuildRequires:  ghc-primitive-devel

--- a/test/golden-test-cases/nanospec.spec.golden
+++ b/test/golden-test-cases/nanospec.spec.golden
@@ -25,6 +25,7 @@ Summary:        A lightweight implementation of a subset of Hspec's API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/nats.spec.golden
+++ b/test/golden-test-cases/nats.spec.golden
@@ -24,6 +24,7 @@ Summary:        Natural numbers
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/netpbm.spec.golden
+++ b/test/golden-test-cases/netpbm.spec.golden
@@ -25,6 +25,7 @@ Summary:        Loading PBM, PGM, PPM image files
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-binary-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/network-protocol-xmpp.spec.golden
+++ b/test/golden-test-cases/network-protocol-xmpp.spec.golden
@@ -24,6 +24,7 @@ Summary:        Client library for the XMPP protocol
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-gnuidn-devel

--- a/test/golden-test-cases/network-transport-tcp.spec.golden
+++ b/test/golden-test-cases/network-transport-tcp.spec.golden
@@ -25,6 +25,7 @@ Summary:        TCP instantiation of Network.Transport
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/nix-paths.spec.golden
+++ b/test/golden-test-cases/nix-paths.spec.golden
@@ -24,6 +24,7 @@ Summary:        Knowledge of Nix's installation directories
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-process-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/nvim-hs.spec.golden
+++ b/test/golden-test-cases/nvim-hs.spec.golden
@@ -25,6 +25,7 @@ Summary:        Haskell plugin backend for neovim
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-ansi-wl-pprint-devel

--- a/test/golden-test-cases/once.spec.golden
+++ b/test/golden-test-cases/once.spec.golden
@@ -24,6 +24,7 @@ Summary:        Memoization for IO actions and functions
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/one-liner.spec.golden
+++ b/test/golden-test-cases/one-liner.spec.golden
@@ -25,6 +25,7 @@ Summary:        Constraint-based generics
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bifunctors-devel
 BuildRequires:  ghc-contravariant-devel

--- a/test/golden-test-cases/online.spec.golden
+++ b/test/golden-test-cases/online.spec.golden
@@ -24,6 +24,7 @@ Summary:        Online statistics
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-foldl-devel
 BuildRequires:  ghc-numhask-devel

--- a/test/golden-test-cases/openexr-write.spec.golden
+++ b/test/golden-test-cases/openexr-write.spec.golden
@@ -25,6 +25,7 @@ Summary:        Library for writing images in OpenEXR HDR file format
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/openpgp-asciiarmor.spec.golden
+++ b/test/golden-test-cases/openpgp-asciiarmor.spec.golden
@@ -25,6 +25,7 @@ Summary:        OpenPGP (RFC4880) ASCII Armor codec
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-base64-bytestring-devel

--- a/test/golden-test-cases/pager.spec.golden
+++ b/test/golden-test-cases/pager.spec.golden
@@ -24,6 +24,7 @@ Summary:        Open up a pager, like 'less' or 'more'
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/pandoc.spec.golden
+++ b/test/golden-test-cases/pandoc.spec.golden
@@ -25,6 +25,7 @@ Summary:        Conversion between markup formats
 License:        GPL-2.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-Glob-devel

--- a/test/golden-test-cases/partial-isomorphisms.spec.golden
+++ b/test/golden-test-cases/partial-isomorphisms.spec.golden
@@ -24,6 +24,7 @@ Summary:        Partial isomorphisms
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-template-haskell-devel

--- a/test/golden-test-cases/partial-semigroup.spec.golden
+++ b/test/golden-test-cases/partial-semigroup.spec.golden
@@ -25,6 +25,7 @@ Summary:        A partial binary associative operator
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/pathtype.spec.golden
+++ b/test/golden-test-cases/pathtype.spec.golden
@@ -25,6 +25,7 @@ Summary:        Type-safe replacement for System.FilePath etc
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/pcap.spec.golden
+++ b/test/golden-test-cases/pcap.spec.golden
@@ -24,6 +24,7 @@ Summary:        A system-independent interface for user-level packet capture
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-network-devel

--- a/test/golden-test-cases/pdfinfo.spec.golden
+++ b/test/golden-test-cases/pdfinfo.spec.golden
@@ -24,6 +24,7 @@ Summary:        Wrapper around the pdfinfo command
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mtl-devel
 BuildRequires:  ghc-old-locale-devel

--- a/test/golden-test-cases/pell.spec.golden
+++ b/test/golden-test-cases/pell.spec.golden
@@ -25,6 +25,7 @@ Summary:        Package to solve the Generalized Pell Equation
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-arithmoi-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/persistable-types-HDBC-pg.spec.golden
+++ b/test/golden-test-cases/persistable-types-HDBC-pg.spec.golden
@@ -24,6 +24,7 @@ Summary:        HDBC and Relational-Record instances of PostgreSQL extended type
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-HDBC-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/persistent-mysql-haskell.spec.golden
+++ b/test/golden-test-cases/persistent-mysql-haskell.spec.golden
@@ -24,6 +24,7 @@ Summary:        A pure haskell backend for the persistent library using MySQL da
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/picosat.spec.golden
+++ b/test/golden-test-cases/picosat.spec.golden
@@ -25,6 +25,7 @@ Summary:        Bindings to the PicoSAT solver
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/pinch.spec.golden
+++ b/test/golden-test-cases/pinch.spec.golden
@@ -25,6 +25,7 @@ Summary:        An alternative implementation of Thrift for Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/pipes-network.spec.golden
+++ b/test/golden-test-cases/pipes-network.spec.golden
@@ -24,6 +24,7 @@ Summary:        Use network sockets together with the pipes library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-network-devel

--- a/test/golden-test-cases/pipes-safe.spec.golden
+++ b/test/golden-test-cases/pipes-safe.spec.golden
@@ -24,6 +24,7 @@ Summary:        Safety for the pipes ecosystem
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-exceptions-devel

--- a/test/golden-test-cases/pointed.spec.golden
+++ b/test/golden-test-cases/pointed.spec.golden
@@ -24,6 +24,7 @@ Summary:        Pointed and copointed data
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-comonad-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/poly-arity.spec.golden
+++ b/test/golden-test-cases/poly-arity.spec.golden
@@ -24,6 +24,7 @@ Summary:        Tools for working with functions of undetermined arity
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-constraints-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/polynomials-bernstein.spec.golden
+++ b/test/golden-test-cases/polynomials-bernstein.spec.golden
@@ -24,6 +24,7 @@ Summary:        A solver for systems of polynomial equations in bernstein form
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-vector-devel

--- a/test/golden-test-cases/postgresql-simple-url.spec.golden
+++ b/test/golden-test-cases/postgresql-simple-url.spec.golden
@@ -25,6 +25,7 @@ Summary:        Parse postgres:// url into ConnectInfo
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-network-uri-devel
 BuildRequires:  ghc-postgresql-simple-devel

--- a/test/golden-test-cases/prelude-safeenum.spec.golden
+++ b/test/golden-test-cases/prelude-safeenum.spec.golden
@@ -24,6 +24,7 @@ Summary:        A redefinition of the Prelude's Enum class in order to render it
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/presburger.spec.golden
+++ b/test/golden-test-cases/presburger.spec.golden
@@ -25,6 +25,7 @@ Summary:        A decision procedure for quantifier-free linear arithmetic
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-pretty-devel

--- a/test/golden-test-cases/prettyclass.spec.golden
+++ b/test/golden-test-cases/prettyclass.spec.golden
@@ -24,6 +24,7 @@ Summary:        Pretty printing class similar to Show
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-pretty-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.spec.golden
+++ b/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.spec.golden
@@ -24,6 +24,7 @@ Summary:        Drop-in compatibility package to migrate from »ansi-wl-pprint«
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-prettyprinter-ansi-terminal-devel
 BuildRequires:  ghc-prettyprinter-devel

--- a/test/golden-test-cases/prettyprinter-compat-wl-pprint.spec.golden
+++ b/test/golden-test-cases/prettyprinter-compat-wl-pprint.spec.golden
@@ -24,6 +24,7 @@ Summary:        Prettyprinter compatibility module for previous users of the wl-
 License:        BSD-2-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-prettyprinter-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/primitive.spec.golden
+++ b/test/golden-test-cases/primitive.spec.golden
@@ -24,6 +24,7 @@ Summary:        Primitive memory-related operations
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-transformers-devel

--- a/test/golden-test-cases/product-profunctors.spec.golden
+++ b/test/golden-test-cases/product-profunctors.spec.golden
@@ -25,6 +25,7 @@ Summary:        Product-profunctors
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-contravariant-devel
 BuildRequires:  ghc-profunctors-devel

--- a/test/golden-test-cases/profiterole.spec.golden
+++ b/test/golden-test-cases/profiterole.spec.golden
@@ -23,6 +23,7 @@ Summary:        Restructure GHC profile reports
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/projectroot.spec.golden
+++ b/test/golden-test-cases/projectroot.spec.golden
@@ -25,6 +25,7 @@ Summary:        Bindings to the projectroot C logic
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-directory-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/proto-lens-optparse.spec.golden
+++ b/test/golden-test-cases/proto-lens-optparse.spec.golden
@@ -24,6 +24,7 @@ Summary:        Adapting proto-lens to optparse-applicative ReadMs
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-optparse-applicative-devel
 BuildRequires:  ghc-proto-lens-devel

--- a/test/golden-test-cases/proto-lens.spec.golden
+++ b/test/golden-test-cases/proto-lens.spec.golden
@@ -24,6 +24,7 @@ Summary:        A lens-based implementation of protocol buffers in Haskell
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/psqueues.spec.golden
+++ b/test/golden-test-cases/psqueues.spec.golden
@@ -25,6 +25,7 @@ Summary:        Pure priority search queues
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/pusher-http-haskell.spec.golden
+++ b/test/golden-test-cases/pusher-http-haskell.spec.golden
@@ -25,6 +25,7 @@ Summary:        Haskell client library for the Pusher HTTP API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-base16-bytestring-devel

--- a/test/golden-test-cases/quickcheck-arbitrary-adt.spec.golden
+++ b/test/golden-test-cases/quickcheck-arbitrary-adt.spec.golden
@@ -25,6 +25,7 @@ Summary:        Generic typeclasses for generating arbitrary ADTs
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/quickcheck-combinators.spec.golden
+++ b/test/golden-test-cases/quickcheck-combinators.spec.golden
@@ -24,6 +24,7 @@ Summary:        Simple type-level combinators for augmenting QuickCheck instance
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/rank1dynamic.spec.golden
+++ b/test/golden-test-cases/rank1dynamic.spec.golden
@@ -25,6 +25,7 @@ Summary:        Like Data.Dynamic/Data.Typeable but with support for rank-1 poly
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/rasterific-svg.spec.golden
+++ b/test/golden-test-cases/rasterific-svg.spec.golden
@@ -24,6 +24,7 @@ Summary:        SVG renderer based on Rasterific
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-FontyFruity-devel

--- a/test/golden-test-cases/ratio-int.spec.golden
+++ b/test/golden-test-cases/ratio-int.spec.golden
@@ -24,6 +24,7 @@ Summary:        Fast specialisation of Data.Ratio for Int
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/rawstring-qm.spec.golden
+++ b/test/golden-test-cases/rawstring-qm.spec.golden
@@ -24,6 +24,7 @@ Summary:        Simple raw string quotation and dictionary interpolation
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/reactive-banana.spec.golden
+++ b/test/golden-test-cases/reactive-banana.spec.golden
@@ -25,6 +25,7 @@ Summary:        Library for functional reactive programming (FRP)
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/readline.spec.golden
+++ b/test/golden-test-cases/readline.spec.golden
@@ -24,6 +24,7 @@ Summary:        An interface to the GNU readline library
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-process-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/rebase.spec.golden
+++ b/test/golden-test-cases/rebase.spec.golden
@@ -24,6 +24,7 @@ Summary:        A more progressive alternative to the "base" package
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-base-prelude-devel
 BuildRequires:  ghc-bifunctors-devel

--- a/test/golden-test-cases/reform-blaze.spec.golden
+++ b/test/golden-test-cases/reform-blaze.spec.golden
@@ -24,6 +24,7 @@ Summary:        Add support for using blaze-html with Reform
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-html-devel
 BuildRequires:  ghc-blaze-markup-devel

--- a/test/golden-test-cases/reform-hsp.spec.golden
+++ b/test/golden-test-cases/reform-hsp.spec.golden
@@ -24,6 +24,7 @@ Summary:        Add support for using HSP with Reform
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hsp-devel
 BuildRequires:  ghc-hsx2hs-devel

--- a/test/golden-test-cases/regex-compat.spec.golden
+++ b/test/golden-test-cases/regex-compat.spec.golden
@@ -24,6 +24,7 @@ Summary:        Replaces/Enhances Text.Regex
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-regex-base-devel

--- a/test/golden-test-cases/regex-pcre.spec.golden
+++ b/test/golden-test-cases/regex-pcre.spec.golden
@@ -24,6 +24,7 @@ Summary:        Replaces/Enhances Text.Regex
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/relational-query.spec.golden
+++ b/test/golden-test-cases/relational-query.spec.golden
@@ -25,6 +25,7 @@ Summary:        Typeful, Modular, Relational, algebraic query engine
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/relational-schemas.spec.golden
+++ b/test/golden-test-cases/relational-schemas.spec.golden
@@ -24,6 +24,7 @@ Summary:        RDBMSs' schema templates for relational-query
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/repa-io.spec.golden
+++ b/test/golden-test-cases/repa-io.spec.golden
@@ -24,6 +24,7 @@ Summary:        Read and write Repa arrays in various formats
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bmp-devel

--- a/test/golden-test-cases/repa.spec.golden
+++ b/test/golden-test-cases/repa.spec.golden
@@ -24,6 +24,7 @@ Summary:        High performance, regular, shape polymorphic parallel arrays
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/rosezipper.spec.golden
+++ b/test/golden-test-cases/rosezipper.spec.golden
@@ -24,6 +24,7 @@ Summary:        Generic zipper implementation for Data.Tree
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/rvar.spec.golden
+++ b/test/golden-test-cases/rvar.spec.golden
@@ -24,6 +24,7 @@ Summary:        Random Variables
 License:        SUSE-Public-Domain
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-MonadPrompt-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/scalpel-core.spec.golden
+++ b/test/golden-test-cases/scalpel-core.spec.golden
@@ -25,6 +25,7 @@ Summary:        A high level web scraping library for Haskell
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/sdl2.spec.golden
+++ b/test/golden-test-cases/sdl2.spec.golden
@@ -24,6 +24,7 @@ Summary:        Both high- and low-level bindings to the SDL library (version 2.
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-StateVar-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/selda-sqlite.spec.golden
+++ b/test/golden-test-cases/selda-sqlite.spec.golden
@@ -24,6 +24,7 @@ Summary:        SQLite backend for the Selda database EDSL
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-direct-sqlite-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/selda.spec.golden
+++ b/test/golden-test-cases/selda.spec.golden
@@ -24,6 +24,7 @@ Summary:        Type-safe, high-level EDSL for interacting with relational datab
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-exceptions-devel

--- a/test/golden-test-cases/servant-checked-exceptions.spec.golden
+++ b/test/golden-test-cases/servant-checked-exceptions.spec.golden
@@ -25,6 +25,7 @@ Summary:        Checked exceptions for Servant APIs
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/set-cover.spec.golden
+++ b/test/golden-test-cases/set-cover.spec.golden
@@ -24,6 +24,7 @@ Summary:        Solve exact set cover problems like Sudoku, 8 Queens, Soma Cube,
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-enummapset-devel

--- a/test/golden-test-cases/sets.spec.golden
+++ b/test/golden-test-cases/sets.spec.golden
@@ -25,6 +25,7 @@ Summary:        Ducktyped set interface for Haskell containers
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-commutative-devel

--- a/test/golden-test-cases/simple-smt.spec.golden
+++ b/test/golden-test-cases/simple-smt.spec.golden
@@ -24,6 +24,7 @@ Summary:        A simple way to interact with an SMT solver process
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-process-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/slack-web.spec.golden
+++ b/test/golden-test-cases/slack-web.spec.golden
@@ -25,6 +25,7 @@ Summary:        Bindings for the Slack web API
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/slug.spec.golden
+++ b/test/golden-test-cases/slug.spec.golden
@@ -25,6 +25,7 @@ Summary:        Type-safe slugs for Yesod ecosystem
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/soxlib.spec.golden
+++ b/test/golden-test-cases/soxlib.spec.golden
@@ -24,6 +24,7 @@ Summary:        Write, read, convert audio signals using libsox
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/speedy-slice.spec.golden
+++ b/test/golden-test-cases/speedy-slice.spec.golden
@@ -25,6 +25,7 @@ Summary:        Speedy slice sampling
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-kan-extensions-devel
 BuildRequires:  ghc-lens-devel

--- a/test/golden-test-cases/splice.spec.golden
+++ b/test/golden-test-cases/splice.spec.golden
@@ -24,6 +24,7 @@ Summary:        Cross-platform Socket to Socket Data Splicing
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-network-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/spreadsheet.spec.golden
+++ b/test/golden-test-cases/spreadsheet.spec.golden
@@ -24,6 +24,7 @@ Summary:        Read and write spreadsheets from and to CSV files in a lazy way
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-explicit-exception-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/stack-type.spec.golden
+++ b/test/golden-test-cases/stack-type.spec.golden
@@ -24,6 +24,7 @@ Summary:        The basic stack type
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-transformers-devel

--- a/test/golden-test-cases/state-codes.spec.golden
+++ b/test/golden-test-cases/state-codes.spec.golden
@@ -25,6 +25,7 @@ Summary:        ISO 3166-2:US state codes and i18n names
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/stb-image-redux.spec.golden
+++ b/test/golden-test-cases/stb-image-redux.spec.golden
@@ -25,6 +25,7 @@ Summary:        Image loading and writing microlibrary
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-vector-devel

--- a/test/golden-test-cases/stm-containers.spec.golden
+++ b/test/golden-test-cases/stm-containers.spec.golden
@@ -25,6 +25,7 @@ Summary:        Containers for STM
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-base-prelude-devel
 BuildRequires:  ghc-focus-devel

--- a/test/golden-test-cases/streaming-commons.spec.golden
+++ b/test/golden-test-cases/streaming-commons.spec.golden
@@ -25,6 +25,7 @@ Summary:        Common lower-level functions needed by various streaming data li
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/strict-base-types.spec.golden
+++ b/test/golden-test-cases/strict-base-types.spec.golden
@@ -24,6 +24,7 @@ Summary:        Strict variants of the types provided in base
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/strict-types.spec.golden
+++ b/test/golden-test-cases/strict-types.spec.golden
@@ -24,6 +24,7 @@ Summary:        A type level predicate ranging over strict types
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/string-class.spec.golden
+++ b/test/golden-test-cases/string-class.spec.golden
@@ -24,6 +24,7 @@ Summary:        String class library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/stripe-haskell.spec.golden
+++ b/test/golden-test-cases/stripe-haskell.spec.golden
@@ -24,6 +24,7 @@ Summary:        Stripe API for Haskell
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-stripe-core-devel

--- a/test/golden-test-cases/svg-tree.spec.golden
+++ b/test/golden-test-cases/svg-tree.spec.golden
@@ -24,6 +24,7 @@ Summary:        SVG file loader and serializer
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-JuicyPixels-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/swagger.spec.golden
+++ b/test/golden-test-cases/swagger.spec.golden
@@ -25,6 +25,7 @@ Summary:        Implementation of swagger data model
 License:        Unknown
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/system-argv0.spec.golden
+++ b/test/golden-test-cases/system-argv0.spec.golden
@@ -24,6 +24,7 @@ Summary:        Get argv[0] as a FilePath
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/system-fileio.spec.golden
+++ b/test/golden-test-cases/system-fileio.spec.golden
@@ -25,6 +25,7 @@ Summary:        Consistent filesystem interaction across GHC versions (deprecate
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/system-filepath.spec.golden
+++ b/test/golden-test-cases/system-filepath.spec.golden
@@ -25,6 +25,7 @@ Summary:        High-level, byte-based file and directory path manipulations (de
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/tagged.spec.golden
+++ b/test/golden-test-cases/tagged.spec.golden
@@ -24,6 +24,7 @@ Summary:        Haskell 98 phantom types to avoid unsafely passing dummy argumen
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/taggy.spec.golden
+++ b/test/golden-test-cases/taggy.spec.golden
@@ -25,6 +25,7 @@ Summary:        Efficient and simple HTML/XML parsing library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/tagstream-conduit.spec.golden
+++ b/test/golden-test-cases/tagstream-conduit.spec.golden
@@ -25,6 +25,7 @@ Summary:        Streamlined html tag parser
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-blaze-builder-devel

--- a/test/golden-test-cases/tasty-hedgehog.spec.golden
+++ b/test/golden-test-cases/tasty-hedgehog.spec.golden
@@ -25,6 +25,7 @@ Summary:        Integrates the hedgehog testing library with the tasty testing f
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hedgehog-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/tasty-rerun.spec.golden
+++ b/test/golden-test-cases/tasty-rerun.spec.golden
@@ -24,6 +24,7 @@ Summary:        Run tests by filtering the test tree depending on the result of 
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/tce-conf.spec.golden
+++ b/test/golden-test-cases/tce-conf.spec.golden
@@ -25,6 +25,7 @@ Summary:        Very simple config file reading
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/terminal-progress-bar.spec.golden
+++ b/test/golden-test-cases/terminal-progress-bar.spec.golden
@@ -25,6 +25,7 @@ Summary:        A simple progress bar in the terminal
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-stm-chans-devel

--- a/test/golden-test-cases/test-fixture.spec.golden
+++ b/test/golden-test-cases/test-fixture.spec.golden
@@ -25,6 +25,7 @@ Summary:        Test monadic side-effects
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-data-default-class-devel
 BuildRequires:  ghc-exceptions-devel

--- a/test/golden-test-cases/texmath.spec.golden
+++ b/test/golden-test-cases/texmath.spec.golden
@@ -25,6 +25,7 @@ Summary:        Conversion between formats used to represent mathematics
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/text-icu.spec.golden
+++ b/test/golden-test-cases/text-icu.spec.golden
@@ -25,6 +25,7 @@ Summary:        Bindings to the ICU library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-deepseq-devel

--- a/test/golden-test-cases/text-postgresql.spec.golden
+++ b/test/golden-test-cases/text-postgresql.spec.golden
@@ -25,6 +25,7 @@ Summary:        Parser and Printer of PostgreSQL extended types
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-dlist-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/th-expand-syns.spec.golden
+++ b/test/golden-test-cases/th-expand-syns.spec.golden
@@ -25,6 +25,7 @@ Summary:        Expands type synonyms in Template Haskell ASTs
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/these.spec.golden
+++ b/test/golden-test-cases/these.spec.golden
@@ -25,6 +25,7 @@ Summary:        An either-or-both data type & a generalized 'zip with padding' t
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/timezone-series.spec.golden
+++ b/test/golden-test-cases/timezone-series.spec.golden
@@ -24,6 +24,7 @@ Summary:        Enhanced timezone handling for Data.Time
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/transformers-compat.spec.golden
+++ b/test/golden-test-cases/transformers-compat.spec.golden
@@ -24,6 +24,7 @@ Summary:        A small compatibility shim exposing the new types from transform
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-transformers-devel

--- a/test/golden-test-cases/transformers-lift.spec.golden
+++ b/test/golden-test-cases/transformers-lift.spec.golden
@@ -24,6 +24,7 @@ Summary:        Ad-hoc type classes for lifting
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 BuildRequires:  ghc-transformers-devel

--- a/test/golden-test-cases/tree-fun.spec.golden
+++ b/test/golden-test-cases/tree-fun.spec.golden
@@ -24,6 +24,7 @@ Summary:        Library for functions pertaining to tree exploration and manipul
 License:        GPL-3.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/ttrie.spec.golden
+++ b/test/golden-test-cases/ttrie.spec.golden
@@ -25,6 +25,7 @@ Summary:        Contention-free STM hash map
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-atomic-primops-devel
 BuildRequires:  ghc-hashable-devel

--- a/test/golden-test-cases/tuple-th.spec.golden
+++ b/test/golden-test-cases/tuple-th.spec.golden
@@ -24,6 +24,7 @@ Summary:        Generate (non-recursive) utility functions for tuples of statica
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/tuples-homogenous-h98.spec.golden
+++ b/test/golden-test-cases/tuples-homogenous-h98.spec.golden
@@ -24,6 +24,7 @@ Summary:        Wrappers for n-ary tuples with Traversable and Applicative/Monad
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/turtle-options.spec.golden
+++ b/test/golden-test-cases/turtle-options.spec.golden
@@ -25,6 +25,7 @@ Summary:        Collection of command line options and parsers for these options
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-optional-args-devel

--- a/test/golden-test-cases/type-operators.spec.golden
+++ b/test/golden-test-cases/type-operators.spec.golden
@@ -24,6 +24,7 @@ Summary:        Various type-level operators
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 

--- a/test/golden-test-cases/type-spec.spec.golden
+++ b/test/golden-test-cases/type-spec.spec.golden
@@ -24,6 +24,7 @@ Summary:        Type Level Specification by Example
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-pretty-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/unicode-show.spec.golden
+++ b/test/golden-test-cases/unicode-show.spec.golden
@@ -25,6 +25,7 @@ Summary:        Print and show in unicode
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/unique.spec.golden
+++ b/test/golden-test-cases/unique.spec.golden
@@ -24,6 +24,7 @@ Summary:        Fully concurrent unique identifiers
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-hashable-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/unix-bytestring.spec.golden
+++ b/test/golden-test-cases/unix-bytestring.spec.golden
@@ -24,6 +24,7 @@ Summary:        Unix/Posix-specific functions for ByteStrings
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/unlit.spec.golden
+++ b/test/golden-test-cases/unlit.spec.golden
@@ -24,6 +24,7 @@ Summary:        Tool to convert literate code between styles or to code
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-directory-devel

--- a/test/golden-test-cases/utility-ht.spec.golden
+++ b/test/golden-test-cases/utility-ht.spec.golden
@@ -25,6 +25,7 @@ Summary:        Various small helper functions for Lists, Maybes, Tuples, Functi
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}

--- a/test/golden-test-cases/validity-aeson.spec.golden
+++ b/test/golden-test-cases/validity-aeson.spec.golden
@@ -24,6 +24,7 @@ Summary:        Validity instances for aeson
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/validity-containers.spec.golden
+++ b/test/golden-test-cases/validity-containers.spec.golden
@@ -24,6 +24,7 @@ Summary:        Validity instances for containers
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/vector-mmap.spec.golden
+++ b/test/golden-test-cases/vector-mmap.spec.golden
@@ -25,6 +25,7 @@ Summary:        Memory map immutable and mutable vectors
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-mmap-devel
 BuildRequires:  ghc-primitive-devel

--- a/test/golden-test-cases/vivid-supercollider.spec.golden
+++ b/test/golden-test-cases/vivid-supercollider.spec.golden
@@ -25,6 +25,7 @@ Summary:        Implementation of SuperCollider server specifications
 License:        GPL-1.0-or-later
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-binary-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/vty.spec.golden
+++ b/test/golden-test-cases/vty.spec.golden
@@ -25,6 +25,7 @@ Summary:        A simple terminal UI library
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-builder-devel

--- a/test/golden-test-cases/wai-cors.spec.golden
+++ b/test/golden-test-cases/wai-cors.spec.golden
@@ -25,6 +25,7 @@ Summary:        CORS for WAI
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-base-unicode-symbols-devel

--- a/test/golden-test-cases/wai-middleware-auth.spec.golden
+++ b/test/golden-test-cases/wai-middleware-auth.spec.golden
@@ -24,6 +24,7 @@ Summary:        Authentication middleware that secures WAI application
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel

--- a/test/golden-test-cases/wai-middleware-caching-redis.spec.golden
+++ b/test/golden-test-cases/wai-middleware-caching-redis.spec.golden
@@ -24,6 +24,7 @@ Summary:        Cache Wai Middleware using Redis backend
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-blaze-builder-devel
 BuildRequires:  ghc-bytestring-devel

--- a/test/golden-test-cases/wai-middleware-prometheus.spec.golden
+++ b/test/golden-test-cases/wai-middleware-prometheus.spec.golden
@@ -25,6 +25,7 @@ Summary:        WAI middlware for exposing http://prometheus.io metrics
 License:        Apache-2.0
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-clock-devel

--- a/test/golden-test-cases/warp.spec.golden
+++ b/test/golden-test-cases/warp.spec.golden
@@ -25,6 +25,7 @@ Summary:        A fast, light-weight web server for WAI applications
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-async-devel

--- a/test/golden-test-cases/weigh.spec.golden
+++ b/test/golden-test-cases/weigh.spec.golden
@@ -25,6 +25,7 @@ Summary:        Measure allocations of a Haskell functions/values
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-deepseq-devel
 BuildRequires:  ghc-mtl-devel

--- a/test/golden-test-cases/xml-hamlet.spec.golden
+++ b/test/golden-test-cases/xml-hamlet.spec.golden
@@ -25,6 +25,7 @@ Summary:        Hamlet-style quasiquoter for XML content
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-parsec-devel

--- a/test/golden-test-cases/xmonad-contrib.spec.golden
+++ b/test/golden-test-cases/xmonad-contrib.spec.golden
@@ -24,6 +24,7 @@ Summary:        Third party extensions for xmonad
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-X11-devel
 BuildRequires:  ghc-X11-xft-devel

--- a/test/golden-test-cases/yahoo-finance-api.spec.golden
+++ b/test/golden-test-cases/yahoo-finance-api.spec.golden
@@ -25,6 +25,7 @@ Summary:        Read quotes from Yahoo Finance API
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-either-devel

--- a/test/golden-test-cases/yesod-form-bootstrap4.spec.golden
+++ b/test/golden-test-cases/yesod-form-bootstrap4.spec.golden
@@ -24,6 +24,7 @@ Summary:        RenderBootstrap4
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-classy-prelude-yesod-devel
 BuildRequires:  ghc-rpm-macros

--- a/test/golden-test-cases/yesod-gitrepo.spec.golden
+++ b/test/golden-test-cases/yesod-gitrepo.spec.golden
@@ -24,6 +24,7 @@ Summary:        Host content provided by a Git repo
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-directory-devel
 BuildRequires:  ghc-enclosed-exceptions-devel

--- a/test/golden-test-cases/yesod-recaptcha2.spec.golden
+++ b/test/golden-test-cases/yesod-recaptcha2.spec.golden
@@ -24,6 +24,7 @@ Summary:        Yesod recaptcha2
 License:        MIT
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-classy-prelude-yesod-devel
 BuildRequires:  ghc-http-conduit-devel

--- a/test/golden-test-cases/zlib.spec.golden
+++ b/test/golden-test-cases/zlib.spec.golden
@@ -25,6 +25,7 @@ Summary:        Compression and decompression in the gzip and zlib formats
 License:        BSD-3-Clause
 URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
+ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
 BuildRequires:  ghc-bytestring-devel
 BuildRequires:  ghc-rpm-macros


### PR DESCRIPTION
Modern versions of GHC compiler don't support i586 architecture.