### PR TITLE
Use explicit naming for -doc and -prof packages

### DIFF
--- a/src/Cabal2Spec.hs
+++ b/src/Cabal2Spec.hs
@@ -196,21 +196,21 @@ createSpecFile specFile pkgDesc forceBinary runTests flagAssignment copyrightYea
     put $ "%description" +-+ ghcPkgDevel
     put $ wrapGenDesc $ "This package provides the Haskell" +-+ pkg_name +-+ "library development files."
     put $ unlines
-        [ "%package doc"
+        [ "%package -n ghc-%{pkg_name}-doc"
         , "Summary:        Haskell %{pkg_name} library documentation"
         , "BuildArch:      noarch"
         , "Requires:       ghc-filesystem"
         , ""
-        , "%description doc"
+        , "%description -n ghc-%{pkg_name}-doc"
         , "This package provides the Haskell %{pkg_name} library documentation."
         , ""
         , ""
-        , "%package prof"
+        , "%package -n ghc-%{pkg_name}-prof"
         , "Summary:        Haskell %{pkg_name} profiling library"
         , "Requires:       %{name}-devel = %{version}-%{release}"
         , "Supplements:    (%{name}-devel and ghc-prof)"
         , ""
-        , "%description prof"
+        , "%description -n ghc-%{pkg_name}-prof"
         , "This package provides the Haskell %{pkg_name} profiling library."
         , ""
         ]
@@ -299,10 +299,10 @@ createSpecFile specFile pkgDesc forceBinary runTests flagAssignment copyrightYea
     unless (null docs) $
       put $ "%doc" +-+ unwords (sort docs)
     putNewline
-    put "%files doc -f %{name}-doc.files"
+    put "%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files"
     mapM_ (\ l -> put $ license_macro +-+ l) licensefiles
     putNewline
-    put "%files prof -f %{name}-prof.files"
+    put "%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files"
     putNewline
 
   put "%changelog"

--- a/test/golden-test-cases/ChasingBottoms.spec.golden
+++ b/test/golden-test-cases/ChasingBottoms.spec.golden
@@ -146,21 +146,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -190,9 +190,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENCE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/Clipboard.spec.golden
+++ b/test/golden-test-cases/Clipboard.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/FenwickTree.spec.golden
+++ b/test/golden-test-cases/FenwickTree.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/GPipe-GLFW.spec.golden
+++ b/test/golden-test-cases/GPipe-GLFW.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/GenericPretty.spec.golden
+++ b/test/golden-test-cases/GenericPretty.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -125,9 +125,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/HPDF.spec.golden
+++ b/test/golden-test-cases/HPDF.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -126,9 +126,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc NEWS.txt README.txt TODO.txt changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/HTF.spec.golden
+++ b/test/golden-test-cases/HTF.spec.golden
@@ -126,21 +126,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -174,9 +174,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog README.md TODO.org
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/HTTP.spec.golden
+++ b/test/golden-test-cases/HTTP.spec.golden
@@ -129,21 +129,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -175,9 +175,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/Hclip.spec.golden
+++ b/test/golden-test-cases/Hclip.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/MissingH.spec.golden
+++ b/test/golden-test-cases/MissingH.spec.golden
@@ -94,21 +94,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -140,9 +140,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc TODO examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ObjectName.spec.golden
+++ b/test/golden-test-cases/ObjectName.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/Only.spec.golden
+++ b/test/golden-test-cases/Only.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,9 +95,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/QuasiText.spec.golden
+++ b/test/golden-test-cases/QuasiText.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/QuickCheck.spec.golden
+++ b/test/golden-test-cases/QuickCheck.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -126,9 +126,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README changelog examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ReadArgs.spec.golden
+++ b/test/golden-test-cases/ReadArgs.spec.golden
@@ -101,21 +101,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -146,9 +146,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/SHA.spec.golden
+++ b/test/golden-test-cases/SHA.spec.golden
@@ -71,21 +71,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -115,9 +115,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/Strafunski-StrategyLib.spec.golden
+++ b/test/golden-test-cases/Strafunski-StrategyLib.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/accelerate-fftw.spec.golden
+++ b/test/golden-test-cases/accelerate-fftw.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/accelerate.spec.golden
+++ b/test/golden-test-cases/accelerate.spec.golden
@@ -183,21 +183,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -226,9 +226,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/active.spec.golden
+++ b/test/golden-test-cases/active.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/adjunctions.spec.golden
+++ b/test/golden-test-cases/adjunctions.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/aeson-diff.spec.golden
+++ b/test/golden-test-cases/aeson-diff.spec.golden
@@ -91,21 +91,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -140,9 +140,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/aeson-pretty.spec.golden
+++ b/test/golden-test-cases/aeson-pretty.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -127,9 +127,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/algebraic-graphs.spec.golden
+++ b/test/golden-test-cases/algebraic-graphs.spec.golden
@@ -91,21 +91,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -137,9 +137,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-cloudtrail.spec.golden
+++ b/test/golden-test-cases/amazonka-cloudtrail.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-cloudwatch-logs.spec.golden
+++ b/test/golden-test-cases/amazonka-cloudwatch-logs.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-codedeploy.spec.golden
+++ b/test/golden-test-cases/amazonka-codedeploy.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-cognito-idp.spec.golden
+++ b/test/golden-test-cases/amazonka-cognito-idp.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-ecs.spec.golden
+++ b/test/golden-test-cases/amazonka-ecs.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-kms.spec.golden
+++ b/test/golden-test-cases/amazonka-kms.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-lightsail.spec.golden
+++ b/test/golden-test-cases/amazonka-lightsail.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-route53-domains.spec.golden
+++ b/test/golden-test-cases/amazonka-route53-domains.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/amazonka-waf.spec.golden
+++ b/test/golden-test-cases/amazonka-waf.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/api-field-json-th.spec.golden
+++ b/test/golden-test-cases/api-field-json-th.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/app-settings.spec.golden
+++ b/test/golden-test-cases/app-settings.spec.golden
@@ -142,21 +142,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -186,9 +186,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/apply-refact.spec.golden
+++ b/test/golden-test-cases/apply-refact.spec.golden
@@ -91,21 +91,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -138,9 +138,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/async.spec.golden
+++ b/test/golden-test-cases/async.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/attoparsec-expr.spec.golden
+++ b/test/golden-test-cases/attoparsec-expr.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/attoparsec-time.spec.golden
+++ b/test/golden-test-cases/attoparsec-time.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/avers-server.spec.golden
+++ b/test/golden-test-cases/avers-server.spec.golden
@@ -97,21 +97,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -138,9 +138,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/aws.spec.golden
+++ b/test/golden-test-cases/aws.spec.golden
@@ -146,21 +146,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -192,9 +192,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/bbdb.spec.golden
+++ b/test/golden-test-cases/bbdb.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/benchpress.spec.golden
+++ b/test/golden-test-cases/benchpress.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/binary-bits.spec.golden
+++ b/test/golden-test-cases/binary-bits.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -111,9 +111,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/binary-tagged.spec.golden
+++ b/test/golden-test-cases/binary-tagged.spec.golden
@@ -98,21 +98,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -144,9 +144,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/bindings-uname.spec.golden
+++ b/test/golden-test-cases/bindings-uname.spec.golden
@@ -52,21 +52,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -91,8 +91,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/bioalign.spec.golden
+++ b/test/golden-test-cases/bioalign.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/bits.spec.golden
+++ b/test/golden-test-cases/bits.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS.markdown CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/blank-canvas.spec.golden
+++ b/test/golden-test-cases/blank-canvas.spec.golden
@@ -120,21 +120,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -171,9 +171,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changelog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/blaze-html.spec.golden
+++ b/test/golden-test-cases/blaze-html.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/blaze-markup.spec.golden
+++ b/test/golden-test-cases/blaze-markup.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/blaze-svg.spec.golden
+++ b/test/golden-test-cases/blaze-svg.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/blosum.spec.golden
+++ b/test/golden-test-cases/blosum.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/boomerang.spec.golden
+++ b/test/golden-test-cases/boomerang.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -99,9 +99,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/boxes.spec.golden
+++ b/test/golden-test-cases/boxes.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/brittany.spec.golden
+++ b/test/golden-test-cases/brittany.spec.golden
@@ -125,21 +125,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -173,9 +173,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md doc
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/broadcast-chan.spec.golden
+++ b/test/golden-test-cases/broadcast-chan.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/butcher.spec.golden
+++ b/test/golden-test-cases/butcher.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -123,9 +123,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/bzlib.spec.golden
+++ b/test/golden-test-cases/bzlib.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/case-insensitive.spec.golden
+++ b/test/golden-test-cases/case-insensitive.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/cassava-conduit.spec.golden
+++ b/test/golden-test-cases/cassava-conduit.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license etc/LICENCE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/cassette.spec.golden
+++ b/test/golden-test-cases/cassette.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,9 +95,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/cereal-text.spec.golden
+++ b/test/golden-test-cases/cereal-text.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/cheapskate.spec.golden
+++ b/test/golden-test-cases/cheapskate.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -124,9 +124,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/chell.spec.golden
+++ b/test/golden-test-cases/chell.spec.golden
@@ -89,21 +89,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -130,9 +130,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/clumpiness.spec.golden
+++ b/test/golden-test-cases/clumpiness.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/code-page.spec.golden
+++ b/test/golden-test-cases/code-page.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/colorize-haskell.spec.golden
+++ b/test/golden-test-cases/colorize-haskell.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/countable.spec.golden
+++ b/test/golden-test-cases/countable.spec.golden
@@ -88,21 +88,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -132,9 +132,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/cpu.spec.golden
+++ b/test/golden-test-cases/cpu.spec.golden
@@ -52,21 +52,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,9 +95,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/criterion.spec.golden
+++ b/test/golden-test-cases/criterion.spec.golden
@@ -131,21 +131,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -185,9 +185,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown changelog.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/crypt-sha512.spec.golden
+++ b/test/golden-test-cases/crypt-sha512.spec.golden
@@ -72,21 +72,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/crypto-random-api.spec.golden
+++ b/test/golden-test-cases/crypto-random-api.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/csv.spec.golden
+++ b/test/golden-test-cases/csv.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license COPYING
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/data-accessor.spec.golden
+++ b/test/golden-test-cases/data-accessor.spec.golden
@@ -104,21 +104,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -145,9 +145,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/data-default-instances-containers.spec.golden
+++ b/test/golden-test-cases/data-default-instances-containers.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/data-endian.spec.golden
+++ b/test/golden-test-cases/data-endian.spec.golden
@@ -51,21 +51,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -92,9 +92,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/data-msgpack.spec.golden
+++ b/test/golden-test-cases/data-msgpack.spec.golden
@@ -85,21 +85,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -131,9 +131,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/data-serializer.spec.golden
+++ b/test/golden-test-cases/data-serializer.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/deque.spec.golden
+++ b/test/golden-test-cases/deque.spec.golden
@@ -52,21 +52,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -93,9 +93,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/dhall-bash.spec.golden
+++ b/test/golden-test-cases/dhall-bash.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/diagrams-solve.spec.golden
+++ b/test/golden-test-cases/diagrams-solve.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/discrimination.spec.golden
+++ b/test/golden-test-cases/discrimination.spec.golden
@@ -84,21 +84,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -127,9 +127,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/dotenv.spec.golden
+++ b/test/golden-test-cases/dotenv.spec.golden
@@ -100,21 +100,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -152,9 +152,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/dotnet-timespan.spec.golden
+++ b/test/golden-test-cases/dotnet-timespan.spec.golden
@@ -51,21 +51,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,9 +94,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/dpor.spec.golden
+++ b/test/golden-test-cases/dpor.spec.golden
@@ -85,21 +85,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -126,9 +126,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/drawille.spec.golden
+++ b/test/golden-test-cases/drawille.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/drifter-postgresql.spec.golden
+++ b/test/golden-test-cases/drifter-postgresql.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -123,9 +123,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ede.spec.golden
+++ b/test/golden-test-cases/ede.spec.golden
@@ -120,21 +120,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -171,9 +171,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ekg-cloudwatch.spec.golden
+++ b/test/golden-test-cases/ekg-cloudwatch.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/emailaddress.spec.golden
+++ b/test/golden-test-cases/emailaddress.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/envelope.spec.golden
+++ b/test/golden-test-cases/envelope.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/eventful-sqlite.spec.golden
+++ b/test/golden-test-cases/eventful-sqlite.spec.golden
@@ -78,21 +78,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -124,9 +124,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/exact-pi.spec.golden
+++ b/test/golden-test-cases/exact-pi.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/expiring-cache-map.spec.golden
+++ b/test/golden-test-cases/expiring-cache-map.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/explicit-exception.spec.golden
+++ b/test/golden-test-cases/explicit-exception.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -114,9 +114,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/fdo-notify.spec.golden
+++ b/test/golden-test-cases/fdo-notify.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/fgl.spec.golden
+++ b/test/golden-test-cases/fgl.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -115,9 +115,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/file-modules.spec.golden
+++ b/test/golden-test-cases/file-modules.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/fingertree.spec.golden
+++ b/test/golden-test-cases/fingertree.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -119,9 +119,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/fixed-vector.spec.golden
+++ b/test/golden-test-cases/fixed-vector.spec.golden
@@ -93,21 +93,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -139,9 +139,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/fixed.spec.golden
+++ b/test/golden-test-cases/fixed.spec.golden
@@ -51,21 +51,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,9 +94,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/foundation.spec.golden
+++ b/test/golden-test-cases/foundation.spec.golden
@@ -72,21 +72,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/frisby.spec.golden
+++ b/test/golden-test-cases/frisby.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/funcmp.spec.golden
+++ b/test/golden-test-cases/funcmp.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -131,9 +131,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license COPYING
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/functor-classes-compat.spec.golden
+++ b/test/golden-test-cases/functor-classes-compat.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/general-games.spec.golden
+++ b/test/golden-test-cases/general-games.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/generic-lens.spec.golden
+++ b/test/golden-test-cases/generic-lens.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/genvalidity-aeson.spec.golden
+++ b/test/golden-test-cases/genvalidity-aeson.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/genvalidity-hspec-aeson.spec.golden
+++ b/test/golden-test-cases/genvalidity-hspec-aeson.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -121,9 +121,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/genvalidity-hspec-binary.spec.golden
+++ b/test/golden-test-cases/genvalidity-hspec-binary.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/genvalidity-scientific.spec.golden
+++ b/test/golden-test-cases/genvalidity-scientific.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/genvalidity-uuid.spec.golden
+++ b/test/golden-test-cases/genvalidity-uuid.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ghc-syb-utils.spec.golden
+++ b/test/golden-test-cases/ghc-syb-utils.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ghcid.spec.golden
+++ b/test/golden-test-cases/ghcid.spec.golden
@@ -85,21 +85,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -132,9 +132,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.txt README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/giphy-api.spec.golden
+++ b/test/golden-test-cases/giphy-api.spec.golden
@@ -90,21 +90,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -136,9 +136,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/github.spec.golden
+++ b/test/golden-test-cases/github.spec.golden
@@ -129,21 +129,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -175,9 +175,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gl.spec.golden
+++ b/test/golden-test-cases/gl.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown TODO.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-adexchange-buyer.spec.golden
+++ b/test/golden-test-cases/gogol-adexchange-buyer.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-admin-emailmigration.spec.golden
+++ b/test/golden-test-cases/gogol-admin-emailmigration.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-affiliates.spec.golden
+++ b/test/golden-test-cases/gogol-affiliates.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-apps-tasks.spec.golden
+++ b/test/golden-test-cases/gogol-apps-tasks.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-appstate.spec.golden
+++ b/test/golden-test-cases/gogol-appstate.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-blogger.spec.golden
+++ b/test/golden-test-cases/gogol-blogger.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-datastore.spec.golden
+++ b/test/golden-test-cases/gogol-datastore.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-dfareporting.spec.golden
+++ b/test/golden-test-cases/gogol-dfareporting.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-firebase-rules.spec.golden
+++ b/test/golden-test-cases/gogol-firebase-rules.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-gmail.spec.golden
+++ b/test/golden-test-cases/gogol-gmail.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-kgsearch.spec.golden
+++ b/test/golden-test-cases/gogol-kgsearch.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-maps-engine.spec.golden
+++ b/test/golden-test-cases/gogol-maps-engine.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-plus.spec.golden
+++ b/test/golden-test-cases/gogol-plus.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-resourceviews.spec.golden
+++ b/test/golden-test-cases/gogol-resourceviews.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -107,9 +107,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-translate.spec.golden
+++ b/test/golden-test-cases/gogol-translate.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-webmaster-tools.spec.golden
+++ b/test/golden-test-cases/gogol-webmaster-tools.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gogol-youtube.spec.golden
+++ b/test/golden-test-cases/gogol-youtube.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/groundhog-mysql.spec.golden
+++ b/test/golden-test-cases/groundhog-mysql.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/gsasl.spec.golden
+++ b/test/golden-test-cases/gsasl.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hOpenPGP.spec.golden
+++ b/test/golden-test-cases/hOpenPGP.spec.golden
@@ -142,21 +142,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -186,9 +186,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/haddock-library.spec.golden
+++ b/test/golden-test-cases/haddock-library.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -131,10 +131,10 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 %license vendor/attoparsec-0.13.1.0/LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hakyll.spec.golden
+++ b/test/golden-test-cases/hakyll.spec.golden
@@ -153,21 +153,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -226,9 +226,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/happstack-hsp.spec.golden
+++ b/test/golden-test-cases/happstack-hsp.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -111,9 +111,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/harp.spec.golden
+++ b/test/golden-test-cases/harp.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -99,9 +99,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hashtables.spec.golden
+++ b/test/golden-test-cases/hashtables.spec.golden
@@ -128,21 +128,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -171,9 +171,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/haskell-tools-debug.spec.golden
+++ b/test/golden-test-cases/haskell-tools-debug.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/haskell-tools-rewrite.spec.golden
+++ b/test/golden-test-cases/haskell-tools-rewrite.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -123,9 +123,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hasql.spec.golden
+++ b/test/golden-test-cases/hasql.spec.golden
@@ -115,21 +115,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -159,9 +159,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hformat.spec.golden
+++ b/test/golden-test-cases/hformat.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/highlighting-kate.spec.golden
+++ b/test/golden-test-cases/highlighting-kate.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -125,9 +125,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hit.spec.golden
+++ b/test/golden-test-cases/hit.spec.golden
@@ -101,21 +101,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -147,9 +147,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hjson.spec.golden
+++ b/test/golden-test-cases/hjson.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license COPYING
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hmpfr.spec.golden
+++ b/test/golden-test-cases/hmpfr.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hoogle.spec.golden
+++ b/test/golden-test-cases/hoogle.spec.golden
@@ -131,21 +131,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -189,9 +189,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.txt README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hostname-validate.spec.golden
+++ b/test/golden-test-cases/hostname-validate.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hsinstall.spec.golden
+++ b/test/golden-test-cases/hsinstall.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md doc
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hstatsd.spec.golden
+++ b/test/golden-test-cases/hstatsd.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,8 +98,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hsx-jmacro.spec.golden
+++ b/test/golden-test-cases/hsx-jmacro.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -107,9 +107,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md example.hs example2.hs
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hsyslog.spec.golden
+++ b/test/golden-test-cases/hsyslog.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/htoml.spec.golden
+++ b/test/golden-test-cases/htoml.spec.golden
@@ -83,21 +83,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/http-conduit.spec.golden
+++ b/test/golden-test-cases/http-conduit.spec.golden
@@ -115,21 +115,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -161,9 +161,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/http-link-header.spec.golden
+++ b/test/golden-test-cases/http-link-header.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license UNLICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/http-media.spec.golden
+++ b/test/golden-test-cases/http-media.spec.golden
@@ -88,21 +88,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -134,9 +134,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hxt-charproperties.spec.golden
+++ b/test/golden-test-cases/hxt-charproperties.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,9 +94,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hxt-expat.spec.golden
+++ b/test/golden-test-cases/hxt-expat.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/hxt-tagsoup.spec.golden
+++ b/test/golden-test-cases/hxt-tagsoup.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/iconv.spec.golden
+++ b/test/golden-test-cases/iconv.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/incremental-parser.spec.golden
+++ b/test/golden-test-cases/incremental-parser.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -115,9 +115,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/indentation-core.spec.golden
+++ b/test/golden-test-cases/indentation-core.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/indentation-parsec.spec.golden
+++ b/test/golden-test-cases/indentation-parsec.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/inline-c-cpp.spec.golden
+++ b/test/golden-test-cases/inline-c-cpp.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -107,9 +107,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/integer-logarithms.spec.golden
+++ b/test/golden-test-cases/integer-logarithms.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -119,9 +119,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.md readme.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/invariant.spec.golden
+++ b/test/golden-test-cases/invariant.spec.golden
@@ -92,21 +92,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -138,9 +138,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/io-machine.spec.golden
+++ b/test/golden-test-cases/io-machine.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/io-streams-haproxy.spec.golden
+++ b/test/golden-test-cases/io-streams-haproxy.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CONTRIBUTORS
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ip.spec.golden
+++ b/test/golden-test-cases/ip.spec.golden
@@ -100,21 +100,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -144,9 +144,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/iso639.spec.golden
+++ b/test/golden-test-cases/iso639.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/iso8601-time.spec.golden
+++ b/test/golden-test-cases/iso8601-time.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,8 +103,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/jmacro-rpc-happstack.spec.golden
+++ b/test/golden-test-cases/jmacro-rpc-happstack.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/jmacro-rpc.spec.golden
+++ b/test/golden-test-cases/jmacro-rpc.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/jose.spec.golden
+++ b/test/golden-test-cases/jose.spec.golden
@@ -119,21 +119,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -167,9 +167,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/katip-elasticsearch.spec.golden
+++ b/test/golden-test-cases/katip-elasticsearch.spec.golden
@@ -109,21 +109,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -155,9 +155,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/katip.spec.golden
+++ b/test/golden-test-cases/katip.spec.golden
@@ -122,21 +122,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -168,9 +168,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/katydid.spec.golden
+++ b/test/golden-test-cases/katydid.spec.golden
@@ -90,21 +90,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -138,9 +138,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/kawhi.spec.golden
+++ b/test/golden-test-cases/kawhi.spec.golden
@@ -84,21 +84,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -130,9 +130,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/kraken.spec.golden
+++ b/test/golden-test-cases/kraken.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/l10n.spec.golden
+++ b/test/golden-test-cases/l10n.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lambdabot-social-plugins.spec.golden
+++ b/test/golden-test-cases/lambdabot-social-plugins.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lazy-csv.spec.golden
+++ b/test/golden-test-cases/lazy-csv.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.html
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENCE-BSD3
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lens-aeson.spec.golden
+++ b/test/golden-test-cases/lens-aeson.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -126,9 +126,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS.markdown CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lens.spec.golden
+++ b/test/golden-test-cases/lens.spec.golden
@@ -221,21 +221,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -267,9 +267,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS.markdown CHANGELOG.markdown README.markdown examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/libgit.spec.golden
+++ b/test/golden-test-cases/libgit.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/librato.spec.golden
+++ b/test/golden-test-cases/librato.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lifted-async.spec.golden
+++ b/test/golden-test-cases/lifted-async.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -121,9 +121,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lmdb.spec.golden
+++ b/test/golden-test-cases/lmdb.spec.golden
@@ -65,21 +65,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/logging-effect-extra-file.spec.golden
+++ b/test/golden-test-cases/logging-effect-extra-file.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,8 +103,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md LICENSE.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/lucid.spec.golden
+++ b/test/golden-test-cases/lucid.spec.golden
@@ -81,21 +81,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -127,9 +127,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mainland-pretty.spec.golden
+++ b/test/golden-test-cases/mainland-pretty.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/matrices.spec.golden
+++ b/test/golden-test-cases/matrices.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -111,9 +111,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/median-stream.spec.golden
+++ b/test/golden-test-cases/median-stream.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/megaparsec.spec.golden
+++ b/test/golden-test-cases/megaparsec.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -125,9 +125,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS.md CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mersenne-random.spec.golden
+++ b/test/golden-test-cases/mersenne-random.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/messagepack.spec.golden
+++ b/test/golden-test-cases/messagepack.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/microlens-ghc.spec.golden
+++ b/test/golden-test-cases/microlens-ghc.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/microlens.spec.golden
+++ b/test/golden-test-cases/microlens.spec.golden
@@ -106,21 +106,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -149,9 +149,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/minio-hs.spec.golden
+++ b/test/golden-test-cases/minio-hs.spec.golden
@@ -129,21 +129,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -173,9 +173,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mmorph.spec.golden
+++ b/test/golden-test-cases/mmorph.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mnist-idx.spec.golden
+++ b/test/golden-test-cases/mnist-idx.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/monad-products.spec.golden
+++ b/test/golden-test-cases/monad-products.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/monadcryptorandom.spec.golden
+++ b/test/golden-test-cases/monadcryptorandom.spec.golden
@@ -65,21 +65,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/monadloc.spec.golden
+++ b/test/golden-test-cases/monadloc.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -115,8 +115,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mongoDB.spec.golden
+++ b/test/golden-test-cases/mongoDB.spec.golden
@@ -116,21 +116,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -162,9 +162,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/monoid-extras.spec.golden
+++ b/test/golden-test-cases/monoid-extras.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mwc-random-monad.spec.golden
+++ b/test/golden-test-cases/mwc-random-monad.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/mwc-random.spec.golden
+++ b/test/golden-test-cases/mwc-random.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/nanospec.spec.golden
+++ b/test/golden-test-cases/nanospec.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/nats.spec.golden
+++ b/test/golden-test-cases/nats.spec.golden
@@ -49,21 +49,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -92,9 +92,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/netpbm.spec.golden
+++ b/test/golden-test-cases/netpbm.spec.golden
@@ -89,21 +89,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -131,8 +131,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/network-protocol-xmpp.spec.golden
+++ b/test/golden-test-cases/network-protocol-xmpp.spec.golden
@@ -72,21 +72,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/network-transport-tcp.spec.golden
+++ b/test/golden-test-cases/network-transport-tcp.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/nix-paths.spec.golden
+++ b/test/golden-test-cases/nix-paths.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/nvim-hs.spec.golden
+++ b/test/golden-test-cases/nvim-hs.spec.golden
@@ -151,21 +151,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -199,9 +199,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/once.spec.golden
+++ b/test/golden-test-cases/once.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/one-liner.spec.golden
+++ b/test/golden-test-cases/one-liner.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/online.spec.golden
+++ b/test/golden-test-cases/online.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc readme.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/openexr-write.spec.golden
+++ b/test/golden-test-cases/openexr-write.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -121,9 +121,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/openpgp-asciiarmor.spec.golden
+++ b/test/golden-test-cases/openpgp-asciiarmor.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pager.spec.golden
+++ b/test/golden-test-cases/pager.spec.golden
@@ -79,21 +79,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -126,9 +126,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pandoc.spec.golden
+++ b/test/golden-test-cases/pandoc.spec.golden
@@ -187,21 +187,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -382,9 +382,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS.md README.md changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license COPYING.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/partial-isomorphisms.spec.golden
+++ b/test/golden-test-cases/partial-isomorphisms.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/partial-semigroup.spec.golden
+++ b/test/golden-test-cases/partial-semigroup.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pathtype.spec.golden
+++ b/test/golden-test-cases/pathtype.spec.golden
@@ -108,21 +108,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -154,9 +154,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pcap.spec.golden
+++ b/test/golden-test-cases/pcap.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pdfinfo.spec.golden
+++ b/test/golden-test-cases/pdfinfo.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pell.spec.golden
+++ b/test/golden-test-cases/pell.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/persistable-types-HDBC-pg.spec.golden
+++ b/test/golden-test-cases/persistable-types-HDBC-pg.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc example
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/persistent-mysql-haskell.spec.golden
+++ b/test/golden-test-cases/persistent-mysql-haskell.spec.golden
@@ -96,21 +96,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -141,9 +141,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/picosat.spec.golden
+++ b/test/golden-test-cases/picosat.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pinch.spec.golden
+++ b/test/golden-test-cases/pinch.spec.golden
@@ -87,21 +87,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -133,9 +133,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md README.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pipes-network.spec.golden
+++ b/test/golden-test-cases/pipes-network.spec.golden
@@ -77,21 +77,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pipes-safe.spec.golden
+++ b/test/golden-test-cases/pipes-safe.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -125,9 +125,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pointed.spec.golden
+++ b/test/golden-test-cases/pointed.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -118,9 +118,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/poly-arity.spec.golden
+++ b/test/golden-test-cases/poly-arity.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,9 +94,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/polynomials-bernstein.spec.golden
+++ b/test/golden-test-cases/polynomials-bernstein.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/postgresql-simple-url.spec.golden
+++ b/test/golden-test-cases/postgresql-simple-url.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/prelude-safeenum.spec.golden
+++ b/test/golden-test-cases/prelude-safeenum.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS CHANGELOG README
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/presburger.spec.golden
+++ b/test/golden-test-cases/presburger.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/prettyclass.spec.golden
+++ b/test/golden-test-cases/prettyclass.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,8 +94,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.spec.golden
+++ b/test/golden-test-cases/prettyprinter-compat-ansi-wl-pprint.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CONTRIBUTORS.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/prettyprinter-compat-wl-pprint.spec.golden
+++ b/test/golden-test-cases/prettyprinter-compat-wl-pprint.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CONTRIBUTORS.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/primitive.spec.golden
+++ b/test/golden-test-cases/primitive.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/product-profunctors.spec.golden
+++ b/test/golden-test-cases/product-profunctors.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -105,9 +105,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/projectroot.spec.golden
+++ b/test/golden-test-cases/projectroot.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/proto-lens-optparse.spec.golden
+++ b/test/golden-test-cases/proto-lens-optparse.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/proto-lens.spec.golden
+++ b/test/golden-test-cases/proto-lens.spec.golden
@@ -78,21 +78,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -121,9 +121,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/psqueues.spec.golden
+++ b/test/golden-test-cases/psqueues.spec.golden
@@ -109,21 +109,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -155,9 +155,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/pusher-http-haskell.spec.golden
+++ b/test/golden-test-cases/pusher-http-haskell.spec.golden
@@ -90,21 +90,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -134,9 +134,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/quickcheck-arbitrary-adt.spec.golden
+++ b/test/golden-test-cases/quickcheck-arbitrary-adt.spec.golden
@@ -65,21 +65,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/quickcheck-combinators.spec.golden
+++ b/test/golden-test-cases/quickcheck-combinators.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rank1dynamic.spec.golden
+++ b/test/golden-test-cases/rank1dynamic.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rasterific-svg.spec.golden
+++ b/test/golden-test-cases/rasterific-svg.spec.golden
@@ -89,21 +89,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -134,9 +134,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ratio-int.spec.golden
+++ b/test/golden-test-cases/ratio-int.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -93,8 +93,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rawstring-qm.spec.golden
+++ b/test/golden-test-cases/rawstring-qm.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/reactive-banana.spec.golden
+++ b/test/golden-test-cases/reactive-banana.spec.golden
@@ -88,21 +88,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -134,9 +134,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md doc
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/readline.spec.golden
+++ b/test/golden-test-cases/readline.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,9 +95,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rebase.spec.golden
+++ b/test/golden-test-cases/rebase.spec.golden
@@ -116,21 +116,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -157,9 +157,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/reform-blaze.spec.golden
+++ b/test/golden-test-cases/reform-blaze.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/reform-hsp.spec.golden
+++ b/test/golden-test-cases/reform-hsp.spec.golden
@@ -60,21 +60,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -101,9 +101,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/regex-compat.spec.golden
+++ b/test/golden-test-cases/regex-compat.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/regex-pcre.spec.golden
+++ b/test/golden-test-cases/regex-pcre.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/relational-query.spec.golden
+++ b/test/golden-test-cases/relational-query.spec.golden
@@ -87,21 +87,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -133,9 +133,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/relational-schemas.spec.golden
+++ b/test/golden-test-cases/relational-schemas.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/repa-io.spec.golden
+++ b/test/golden-test-cases/repa-io.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/repa.spec.golden
+++ b/test/golden-test-cases/repa.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -103,9 +103,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rosezipper.spec.golden
+++ b/test/golden-test-cases/rosezipper.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -94,9 +94,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/rvar.spec.golden
+++ b/test/golden-test-cases/rvar.spec.golden
@@ -71,21 +71,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,8 +110,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/scalpel-core.spec.golden
+++ b/test/golden-test-cases/scalpel-core.spec.golden
@@ -76,21 +76,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,9 +122,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/sdl2.spec.golden
+++ b/test/golden-test-cases/sdl2.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/selda-sqlite.spec.golden
+++ b/test/golden-test-cases/selda-sqlite.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/selda.spec.golden
+++ b/test/golden-test-cases/selda.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/servant-checked-exceptions.spec.golden
+++ b/test/golden-test-cases/servant-checked-exceptions.spec.golden
@@ -92,21 +92,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -138,9 +138,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/set-cover.spec.golden
+++ b/test/golden-test-cases/set-cover.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changes.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/sets.spec.golden
+++ b/test/golden-test-cases/sets.spec.golden
@@ -90,21 +90,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -134,9 +134,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/simple-smt.spec.golden
+++ b/test/golden-test-cases/simple-smt.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/slack-web.spec.golden
+++ b/test/golden-test-cases/slack-web.spec.golden
@@ -82,21 +82,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -128,9 +128,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/slug.spec.golden
+++ b/test/golden-test-cases/slug.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE.md
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/soxlib.spec.golden
+++ b/test/golden-test-cases/soxlib.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/speedy-slice.spec.golden
+++ b/test/golden-test-cases/speedy-slice.spec.golden
@@ -87,21 +87,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -131,9 +131,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/splice.spec.golden
+++ b/test/golden-test-cases/splice.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/spreadsheet.spec.golden
+++ b/test/golden-test-cases/spreadsheet.spec.golden
@@ -80,21 +80,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -123,9 +123,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/stack-type.spec.golden
+++ b/test/golden-test-cases/stack-type.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/state-codes.spec.golden
+++ b/test/golden-test-cases/state-codes.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/stb-image-redux.spec.golden
+++ b/test/golden-test-cases/stb-image-redux.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/stm-containers.spec.golden
+++ b/test/golden-test-cases/stm-containers.spec.golden
@@ -88,21 +88,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -132,9 +132,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/streaming-commons.spec.golden
+++ b/test/golden-test-cases/streaming-commons.spec.golden
@@ -87,21 +87,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -133,9 +133,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/strict-base-types.spec.golden
+++ b/test/golden-test-cases/strict-base-types.spec.golden
@@ -132,21 +132,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -175,9 +175,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/strict-types.spec.golden
+++ b/test/golden-test-cases/strict-types.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/string-class.spec.golden
+++ b/test/golden-test-cases/string-class.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/stripe-haskell.spec.golden
+++ b/test/golden-test-cases/stripe-haskell.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/svg-tree.spec.golden
+++ b/test/golden-test-cases/svg-tree.spec.golden
@@ -81,21 +81,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -122,8 +122,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/swagger.spec.golden
+++ b/test/golden-test-cases/swagger.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/system-argv0.spec.golden
+++ b/test/golden-test-cases/system-argv0.spec.golden
@@ -61,21 +61,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/system-fileio.spec.golden
+++ b/test/golden-test-cases/system-fileio.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/system-filepath.spec.golden
+++ b/test/golden-test-cases/system-filepath.spec.golden
@@ -66,21 +66,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license license.txt
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tagged.spec.golden
+++ b/test/golden-test-cases/tagged.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/taggy.spec.golden
+++ b/test/golden-test-cases/taggy.spec.golden
@@ -102,21 +102,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -151,9 +151,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tagstream-conduit.spec.golden
+++ b/test/golden-test-cases/tagstream-conduit.spec.golden
@@ -85,21 +85,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -129,9 +129,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tasty-hedgehog.spec.golden
+++ b/test/golden-test-cases/tasty-hedgehog.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tasty-rerun.spec.golden
+++ b/test/golden-test-cases/tasty-rerun.spec.golden
@@ -110,21 +110,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -153,9 +153,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc Changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tce-conf.spec.golden
+++ b/test/golden-test-cases/tce-conf.spec.golden
@@ -62,21 +62,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -111,9 +111,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md TODO.md changelog.md doc
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/terminal-progress-bar.spec.golden
+++ b/test/golden-test-cases/terminal-progress-bar.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -119,9 +119,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/test-fixture.spec.golden
+++ b/test/golden-test-cases/test-fixture.spec.golden
@@ -74,21 +74,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -120,9 +120,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/texmath.spec.golden
+++ b/test/golden-test-cases/texmath.spec.golden
@@ -103,21 +103,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -149,9 +149,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown changelog
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/text-icu.spec.golden
+++ b/test/golden-test-cases/text-icu.spec.golden
@@ -102,21 +102,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -148,9 +148,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.markdown changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/text-postgresql.spec.golden
+++ b/test/golden-test-cases/text-postgresql.spec.golden
@@ -65,21 +65,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -109,9 +109,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/th-expand-syns.spec.golden
+++ b/test/golden-test-cases/th-expand-syns.spec.golden
@@ -58,21 +58,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/these.spec.golden
+++ b/test/golden-test-cases/these.spec.golden
@@ -104,21 +104,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -150,9 +150,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/timezone-series.spec.golden
+++ b/test/golden-test-cases/timezone-series.spec.golden
@@ -59,21 +59,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -102,9 +102,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/transformers-compat.spec.golden
+++ b/test/golden-test-cases/transformers-compat.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/transformers-lift.spec.golden
+++ b/test/golden-test-cases/transformers-lift.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tree-fun.spec.golden
+++ b/test/golden-test-cases/tree-fun.spec.golden
@@ -55,21 +55,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -98,9 +98,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/ttrie.spec.golden
+++ b/test/golden-test-cases/ttrie.spec.golden
@@ -78,21 +78,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -124,9 +124,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md changelog.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tuple-th.spec.golden
+++ b/test/golden-test-cases/tuple-th.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/tuples-homogenous-h98.spec.golden
+++ b/test/golden-test-cases/tuples-homogenous-h98.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,9 +95,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/turtle-options.spec.golden
+++ b/test/golden-test-cases/turtle-options.spec.golden
@@ -65,21 +65,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -113,9 +113,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/type-operators.spec.golden
+++ b/test/golden-test-cases/type-operators.spec.golden
@@ -52,21 +52,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -93,9 +93,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/type-spec.spec.golden
+++ b/test/golden-test-cases/type-spec.spec.golden
@@ -54,21 +54,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/unicode-show.spec.golden
+++ b/test/golden-test-cases/unicode-show.spec.golden
@@ -72,21 +72,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/unique.spec.golden
+++ b/test/golden-test-cases/unique.spec.golden
@@ -53,21 +53,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -96,9 +96,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.markdown README.markdown
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/unix-bytestring.spec.golden
+++ b/test/golden-test-cases/unix-bytestring.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/unlit.spec.golden
+++ b/test/golden-test-cases/unlit.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -106,9 +106,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/utility-ht.spec.golden
+++ b/test/golden-test-cases/utility-ht.spec.golden
@@ -68,21 +68,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/validity-aeson.spec.golden
+++ b/test/golden-test-cases/validity-aeson.spec.golden
@@ -63,21 +63,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -104,9 +104,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/validity-containers.spec.golden
+++ b/test/golden-test-cases/validity-containers.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -97,9 +97,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/vector-mmap.spec.golden
+++ b/test/golden-test-cases/vector-mmap.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -108,9 +108,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/vivid-supercollider.spec.golden
+++ b/test/golden-test-cases/vivid-supercollider.spec.golden
@@ -75,21 +75,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -117,8 +117,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/vty.spec.golden
+++ b/test/golden-test-cases/vty.spec.golden
@@ -128,21 +128,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -177,9 +177,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc AUTHORS CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/wai-cors.spec.golden
+++ b/test/golden-test-cases/wai-cors.spec.golden
@@ -94,21 +94,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -148,9 +148,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/wai-middleware-auth.spec.golden
+++ b/test/golden-test-cases/wai-middleware-auth.spec.golden
@@ -115,21 +115,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -160,9 +160,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/wai-middleware-caching-redis.spec.golden
+++ b/test/golden-test-cases/wai-middleware-caching-redis.spec.golden
@@ -67,21 +67,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library
 development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -111,9 +111,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/wai-middleware-prometheus.spec.golden
+++ b/test/golden-test-cases/wai-middleware-prometheus.spec.golden
@@ -71,21 +71,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -115,9 +115,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/warp.spec.golden
+++ b/test/golden-test-cases/warp.spec.golden
@@ -124,21 +124,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -170,9 +170,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/weigh.spec.golden
+++ b/test/golden-test-cases/weigh.spec.golden
@@ -64,21 +64,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -110,9 +110,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGELOG README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/xml-hamlet.spec.golden
+++ b/test/golden-test-cases/xml-hamlet.spec.golden
@@ -70,21 +70,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -116,9 +116,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/xmonad-contrib.spec.golden
+++ b/test/golden-test-cases/xmonad-contrib.spec.golden
@@ -92,21 +92,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -135,9 +135,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc CHANGES.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/yahoo-finance-api.spec.golden
+++ b/test/golden-test-cases/yahoo-finance-api.spec.golden
@@ -90,21 +90,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -136,9 +136,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/yesod-form-bootstrap4.spec.golden
+++ b/test/golden-test-cases/yesod-form-bootstrap4.spec.golden
@@ -56,21 +56,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 This package provides the Haskell %{name} library development
 files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -95,8 +95,8 @@ This package provides the Haskell %{pkg_name} profiling library.
 
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/yesod-gitrepo.spec.golden
+++ b/test/golden-test-cases/yesod-gitrepo.spec.golden
@@ -69,21 +69,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -112,9 +112,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc ChangeLog.md README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/yesod-recaptcha2.spec.golden
+++ b/test/golden-test-cases/yesod-recaptcha2.spec.golden
@@ -57,21 +57,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -100,9 +100,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc README.md
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog

--- a/test/golden-test-cases/zlib.spec.golden
+++ b/test/golden-test-cases/zlib.spec.golden
@@ -73,21 +73,21 @@ Requires(postun): ghc-compiler = %{ghc_version}
 %description -n ghc-%{name}-devel
 This package provides the Haskell %{name} library development files.
 
-%package doc
+%package -n ghc-%{pkg_name}-doc
 Summary:        Haskell %{pkg_name} library documentation
 BuildArch:      noarch
 Requires:       ghc-filesystem
 
-%description doc
+%description -n ghc-%{pkg_name}-doc
 This package provides the Haskell %{pkg_name} library documentation.
 
 
-%package prof
+%package -n ghc-%{pkg_name}-prof
 Summary:        Haskell %{pkg_name} profiling library
 Requires:       %{name}-devel = %{version}-%{release}
 Supplements:    (%{name}-devel and ghc-prof)
 
-%description prof
+%description -n ghc-%{pkg_name}-prof
 This package provides the Haskell %{pkg_name} profiling library.
 
 
@@ -119,9 +119,9 @@ This package provides the Haskell %{pkg_name} profiling library.
 %files -n ghc-%{name}-devel -f ghc-%{name}-devel.files
 %doc changelog examples
 
-%files doc -f %{name}-doc.files
+%files -n ghc-%{pkg_name}-doc -f ghc-%{pkg_name}-doc.files
 %license LICENSE
 
-%files prof -f %{name}-prof.files
+%files -n ghc-%{pkg_nanme}-prof -f ghc-%{pkg_name}-prof.files
 
 %changelog


### PR DESCRIPTION
This is simple workaround for packages which have binary as primary but also providing lib.