### PR TITLE
Cabal isn't package integrated to base

### DIFF
--- a/src/Cabal2Spec.hs
+++ b/src/Cabal2Spec.hs
@@ -161,7 +161,7 @@ createSpecFile specFile pkgDesc forceBinary runTests flagAssignment copyrightYea
   putHdr "ExcludeArch" "%{ix86}"
 
   let fixedDeps = ["ghc-Cabal-devel", "ghc-rpm-macros"]
-  let alldeps = sort $ fixedDeps ++ deps ++ tools ++ clibs ++ pkgcfgs ++ ["pkgconfig" | not (null pkgcfgs)]
+  let alldeps = sort $ nub $ fixedDeps ++ deps ++ tools ++ clibs ++ pkgcfgs ++ ["pkgconfig" | not (null pkgcfgs)]
   let extraTestDeps = sort $ testsuiteDeps \\ deps
   unless (null $ alldeps ++ extraTestDeps) $ do
     mapM_ (putHdr "BuildRequires") alldeps
@@ -394,7 +394,7 @@ s +-+ "" = s
 s +-+ t = s ++ " " ++ t
 
 excludedPkgs :: PackageDescription -> String -> Bool
-excludedPkgs pkgDesc = flip notElem (subLibs ++ ["Cabal", "ghc-prim", "integer-gmp", "ghc-bignum"])
+excludedPkgs pkgDesc = flip notElem (subLibs ++ ["ghc-prim", "integer-gmp", "ghc-bignum"])
   where
     subLibs :: [String]
     subLibs = [ unUnqualComponentName ln | l <- subLibraries pkgDesc, LSubLibName ln <- [libName l] ]

--- a/test/golden-test-cases/attoparsec-time.spec.golden
+++ b/test/golden-test-cases/attoparsec-time.spec.golden
@@ -29,6 +29,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-attoparsec-devel
 BuildRequires:  ghc-attoparsec-prof
 BuildRequires:  ghc-base-devel

--- a/test/golden-test-cases/bits.spec.golden
+++ b/test/golden-test-cases/bits.spec.golden
@@ -29,6 +29,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-base-devel
 BuildRequires:  ghc-base-prof
 BuildRequires:  ghc-bytes-devel

--- a/test/golden-test-cases/gl.spec.golden
+++ b/test/golden-test-cases/gl.spec.golden
@@ -29,6 +29,7 @@ Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%
 ExcludeArch:    %{ix86}
 BuildRequires:  Mesa-libGL-devel
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-base-devel
 BuildRequires:  ghc-base-prof
 BuildRequires:  ghc-containers-devel

--- a/test/golden-test-cases/happy.spec.golden
+++ b/test/golden-test-cases/happy.spec.golden
@@ -26,6 +26,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-array-prof
 BuildRequires:  ghc-base-devel

--- a/test/golden-test-cases/hsyslog.spec.golden
+++ b/test/golden-test-cases/hsyslog.spec.golden
@@ -29,6 +29,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-base-devel
 BuildRequires:  ghc-base-prof
 BuildRequires:  ghc-cabal-doctest-devel

--- a/test/golden-test-cases/lens-aeson.spec.golden
+++ b/test/golden-test-cases/lens-aeson.spec.golden
@@ -29,6 +29,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-aeson-devel
 BuildRequires:  ghc-aeson-prof
 BuildRequires:  ghc-attoparsec-devel

--- a/test/golden-test-cases/lens.spec.golden
+++ b/test/golden-test-cases/lens.spec.golden
@@ -29,6 +29,7 @@ URL:            https://hackage.haskell.org/package/%{name}
 Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%{version}.tar.gz
 ExcludeArch:    %{ix86}
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-array-devel
 BuildRequires:  ghc-array-prof
 BuildRequires:  ghc-base-devel

--- a/test/golden-test-cases/pandoc.spec.golden
+++ b/test/golden-test-cases/pandoc.spec.golden
@@ -30,6 +30,7 @@ Source0:        https://hackage.haskell.org/package/%{name}-%{version}/%{name}-%
 ExcludeArch:    %{ix86}
 BuildRequires:  chrpath
 BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-Glob-devel
 BuildRequires:  ghc-Glob-prof
 BuildRequires:  ghc-HTTP-devel

--- a/test/golden-test-cases/pell.spec.golden
+++ b/test/golden-test-cases/pell.spec.golden
@@ -37,6 +37,8 @@ BuildRequires:  ghc-containers-devel
 BuildRequires:  ghc-containers-prof
 BuildRequires:  ghc-rpm-macros
 %if %{with tests}
+BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-QuickCheck-devel
 BuildRequires:  ghc-QuickCheck-prof
 BuildRequires:  ghc-cabal-test-quickcheck-devel

--- a/test/golden-test-cases/vty.spec.golden
+++ b/test/golden-test-cases/vty.spec.golden
@@ -74,6 +74,8 @@ BuildRequires:  ghc-utf8-string-prof
 BuildRequires:  ghc-vector-devel
 BuildRequires:  ghc-vector-prof
 %if %{with tests}
+BuildRequires:  ghc-Cabal-devel
+BuildRequires:  ghc-Cabal-prof
 BuildRequires:  ghc-HUnit-devel
 BuildRequires:  ghc-HUnit-prof
 BuildRequires:  ghc-QuickCheck-devel


### PR DESCRIPTION
This change allows Cabal to be propper dependency with dep on ghc-Cabal-prof as package which depends directly on Cabal needs